### PR TITLE
Removed code coverage from default grunt tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.4 - 2015-12-23 - Wojciech Trocki
+- Removed code coverage from default grunt job.
+
 ## 0.3.3 - 2015-12-23 - Leigh Griffin
 - Updated package.JSON to include Istanbul as a Dev dependency 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-fh-build",
   "description": "A plugin for development and build lifecycle of FeedHenry components",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "homepage": "https://github.com/feedhenry/grunt-fh-build",
   "author": "Red Hat",
   "license": "Apache-2.0",

--- a/tasks/fh-build.js
+++ b/tasks/fh-build.js
@@ -381,7 +381,7 @@ module.exports = function(grunt) {
     } else if (this.target === 'shrinkwrap') {
       grunt.task.run(['shell:fh-run-array:fhshrinkwrap']);
     } else if (this.target === 'default') {
-      grunt.task.run(['jshint', 'fh:coverage', 'fh:analysis', 'fh:dist']);
+      grunt.task.run(['jshint', 'fh:test', 'fh:dist']);
     } else {
       grunt.fail.warn('Unknown target provided to `grunt fh`');
     }


### PR DESCRIPTION
@wei-lee @jasonmadigan Code coverage is now done as part of nightly job. Code coverage for PR's was removed from bob. It makes more sense to remove this from default build target.
