### PR TITLE
Support for single tests cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.0 - 2016-01-05 - Wojciech Trocki
+- Added support for running single test cases.
+
 ## 0.3.4 - 2015-12-23 - Wojciech Trocki
 - Removed code coverage from default grunt job.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ Note: by default, the directory `node_modules/.bin` will be added to the
 beginning of the `PATH` environment variable, so we don't have to specify the
 path to commands, if they reside in that directory.
 
+### fh:testfile
+This target will run the single unit test file for the project. To configure which and how
+tests are run, add a property called `unit_single` to the configuration in your
+Gruntfile.js. Command string should contain `test_filename` placeholder 
+that will be replaced with filename argument at runtime. Additional parameters are supported by specifying
+`unit_test_param1` where 1 is number of parameter after filename.
+This property is an array of commands to run, so that different test runners can be used per project.
+Example for mocha framework with support for running single test method.
+
+    unit_single: ['mocha -A -u exports ./test/helper.js ./test/unit/**/<%= unit_test_filename %> --grep=<%= unit_test_param1 %>''],
+    
+Example:
+
+    grunt fh:testfile:testfile.js
+
 ### fh:integrate
 This target works the same as the `fh:unit` one above, with the exception that
 the property specifying the commands to run will be called `integrate`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-fh-build",
   "description": "A plugin for development and build lifecycle of FeedHenry components",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "homepage": "https://github.com/feedhenry/grunt-fh-build",
   "author": "Red Hat",
   "license": "Apache-2.0",

--- a/tasks/fh-build.js
+++ b/tasks/fh-build.js
@@ -201,6 +201,7 @@ module.exports = function(grunt) {
       default: {},
       analysis: {},
       coverage: {},
+      testfile: {},
       integrate: {},
       shrinkwrap: {},
       'make-version-file': {}
@@ -314,6 +315,27 @@ module.exports = function(grunt) {
     }
   };
 
+  var runTestsForSingleFile = function(args){
+    var testFile = args[0];
+    if (!testFile){
+      grunt.log.errorlns("Please specify test file to run: grunt fh:testfile:filename.js");
+      return;
+    }
+    // Task name (grunt file config variable)
+    var testType = "unit_single";
+    // Task filename parameter (used as template in runtime script)
+    grunt.config.set("unit_test_filename", testFile);
+    for (var index = 1; index < args.length; index++){
+      grunt.config.set("unit_test_param" + index, args[index]);
+    }
+    var cmdArray = grunt.config.get(testType);
+    if (!cmdArray){
+      grunt.log.errorlns("No local config for single tests. Please define " + testType + " property in config.");
+      return;
+    }
+    grunt.task.run(['shell:fh-run-array:' + testType]);
+  }
+
   grunt.registerTask('fh-generate-dockerised-config','Task to generate openshift config file', function() {
     var conf = require(path.resolve('config/dev.json'));
     var placeholders = require(path.resolve('config/ose-placeholders.js'));
@@ -366,6 +388,8 @@ module.exports = function(grunt) {
                       'shell:fh-run-array:accept']);
     } else if (this.target === 'unit') {
       grunt.task.run(['shell:fh-run-array:unit']);
+    } else if (this.target === 'testfile'){
+      runTestsForSingleFile(arguments);
     } else if (this.target === 'integrate') {
       grunt.task.run(['shell:fh-run-array:integrate']);
     } else if (this.target === 'accept') {


### PR DESCRIPTION
Support for running single test cases:
`grunt fh:testfile:test.js`
