### PR TITLE
Fix fh-run-array to take string or array again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-fh-build",
   "description": "A plugin for development and build lifecycle of FeedHenry components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/feedhenry/grunt-fh-build",
   "author": "Red Hat",
   "license": "Apache-2.0",

--- a/tasks/fh-build.js
+++ b/tasks/fh-build.js
@@ -260,9 +260,8 @@ module.exports = function(grunt) {
           var cmd = '';
 
           if (test_type && grunt.config.get(test_type)) {
-            var cmdsString = grunt.config.get(test_type);
-            var cmdArray = cmdsString.split(',');
-            cmd = cmdArray.join(' && ');
+            var cmds = grunt.config.get(test_type);
+            cmd = typeof cmds === 'string' ? cmds : cmds.join(' && ');
           } else {
             grunt.log.warn("Skipping", grunt.task.current.nameArgs,
                            "-- invalid or missing parameter");


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-5713

Motivation:
It turns out that when we moved away from `grunt.template.process` to
`grunt.config.get` in 1.0.0, it returns a non-string, if it finds a
non-string. Useful, but not what we were expecting! :)

Modification:
Only split if it's a string, otherwise assume it's an array with
multiple commands, and join with ' && '.

Result:
Single-command strings, and multi-command arrays work again.
