### PR TITLE
Fix fhignore and fhinclude that are broken in v1+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-fh-build",
   "description": "A plugin for development and build lifecycle of FeedHenry components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/feedhenry/grunt-fh-build",
   "author": "Red Hat",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "node": ">= 0.10.0"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt eslint",
+    "version": "sed -i.bak \"s/sonar.projectVersion=.*/sonar.projectVersion=${npm_package_version}/\" sonar-project.properties && rm sonar-project.properties.bak && git add sonar-project.properties"
   },
   "devDependencies": {
     "grunt": ">=0.4.0"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=grunt-fh-build
 sonar.projectName=grunt-fh-build-nightly-master
-sonar.projectVersion=1.0.0
+sonar.projectVersion=1.0.2
 
 sonar.sources=./tasks
 sonar.language=js

--- a/tasks/fh-build.js
+++ b/tasks/fh-build.js
@@ -72,16 +72,16 @@ module.exports = function(grunt) {
 
     var fhignore = grunt.config.get('fhignore');
     var extras = [];
-    if (typeof fhignore === 'string' && fhignore.length > 0) {
-      extras = fhignore.split(',').map(function(elem) {
+    if (fhignore && _.isArray(fhignore)) {
+      extras = fhignore.map(function(elem) {
         return '!' + elem;
       });
     }
     Array.prototype.push.apply(patterns, extras);
     var fhinclude = grunt.config.get('fhinclude');
     extras = [];
-    if(typeof fhinclude === 'string' && fhinclude.length > 0) {
-      extras = fhinclude.split(',');
+    if(fhinclude && _.isArray(fhinclude)) {
+      extras = fhinclude;
     }
     Array.prototype.push.apply(patterns, extras);
     grunt.log.debug("Patterns: " + patterns);


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-6534

Motivation:
Using `grunt-fh-build@1.y.z` meant that `fhignore` and `fhinclude` were
not working as expected, since they're now more sanely seen as arrays
and not strings. We had a bad condition in there.

Modification:
Fix to work with arrays rather than strings.

Result:
`fhignore` and `fhinclude` properties in `Gruntfile.js` should now be
honoured again.
