### PR TITLE
FH-2703 - shared dependencies are not copied into tarbell cause of np…

### DIFF
--- a/tasks/fh-build.js
+++ b/tasks/fh-build.js
@@ -63,11 +63,11 @@ module.exports = function(grunt) {
       '!**/*.tar.gz'
     ];
     if (bundle_deps) {
-      _.map(_.keys(grunt.file.readJSON('package.json').dependencies),
-            function(dep) {
-              patterns.push('node_modules/' + dep + '/**');
-              return dep;
-            });
+      _.map(fs.readdirSync('node_modules'),
+        function(dep) {
+          patterns.push('node_modules/' + dep + '/**');
+          return dep;
+        });
     }
 
     var fhignore = grunt.config.get('fhignore');


### PR DESCRIPTION
…m3 deduplicating them - fh:dist

## Motivation
The `fh:dist` target will not copy over all dependencies needed when run with npm@3+. The reason for this is that if two or more dependencies share a dependency, npm3 will pull up this dependency to the top of the tree and the problem is that `fh:dist` only copies over dependencies that are defined in the `dependencies` field in `package.json`.  So when a dependency gets pulled up to the top level of the `node_modules` directory this dependency will be excluded from the tarbell created by `fh:dist` which leaves dependencies without the dependencies they depend on to work.

## Result
When creating the build artifact copy over the dependencies by reading them from the `node_modules` directory instead of the `dependencies` field in `package.json`

## Jira
https://issues.jboss.org/browse/FH-2703