### PR TITLE
FH-2703 use npm ls --parseable --production to create bundle

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-fh-build",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "dependencies": {
     "findup-sync": {
       "version": "0.4.3",
@@ -42,9 +42,9 @@
               "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
               "dependencies": {
                 "arr-flatten": {
-                  "version": "1.0.3",
+                  "version": "1.1.0",
                   "from": "arr-flatten@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
                 }
               }
             },
@@ -80,7 +80,7 @@
                           "dependencies": {
                             "isarray": {
                               "version": "1.0.0",
-                              "from": "isarray@1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                             }
                           }
@@ -270,7 +270,7 @@
             "expand-tilde": {
               "version": "1.2.2",
               "from": "expand-tilde@>=1.2.2 <2.0.0",
-              "resolved": "http://npm.skunkhenry.com/expand-tilde/-/expand-tilde-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
@@ -304,11 +304,11 @@
                     "ini": {
                       "version": "1.3.4",
                       "from": "ini@>=1.3.4 <2.0.0",
-                      "resolved": "http://npm.skunkhenry.com/ini/-/ini-1.3.4.tgz"
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                     },
                     "which": {
                       "version": "1.2.14",
-                      "from": "which@>=1.2.1 <1.3.0",
+                      "from": "which@>=1.2.12 <2.0.0",
                       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
                       "dependencies": {
                         "isexe": {
@@ -421,65 +421,48 @@
       }
     },
     "grunt-contrib-compress": {
-      "version": "1.2.0",
-      "from": "grunt-contrib-compress@1.2.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.2.0.tgz",
+      "version": "1.4.3",
+      "from": "grunt-contrib-compress@>=1.4.3 <1.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.4.3.tgz",
       "dependencies": {
         "archiver": {
-          "version": "0.21.0",
-          "from": "archiver@>=0.21.0 <0.22.0",
-          "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.21.0.tgz",
+          "version": "1.3.0",
+          "from": "archiver@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
           "dependencies": {
             "archiver-utils": {
-              "version": "0.3.0",
-              "from": "archiver-utils@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-0.3.0.tgz",
+              "version": "1.3.0",
+              "from": "archiver-utils@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
               "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "from": "graceful-fs@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                },
                 "lazystream": {
-                  "version": "0.1.0",
-                  "from": "lazystream@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                        }
-                      }
-                    }
-                  }
+                  "version": "1.0.0",
+                  "from": "lazystream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
                 },
                 "normalize-path": {
-                  "version": "2.0.1",
-                  "from": "normalize-path@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                  "version": "2.1.1",
+                  "from": "normalize-path@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                  "dependencies": {
+                    "remove-trailing-separator": {
+                      "version": "1.0.2",
+                      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+                    }
+                  }
                 }
               }
             },
             "async": {
-              "version": "1.5.2",
-              "from": "async@>=1.5.0 <1.6.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+              "version": "2.5.0",
+              "from": "async@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz"
             },
             "buffer-crc32": {
               "version": "0.2.13",
@@ -487,10 +470,15 @@
               "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
             },
             "glob": {
-              "version": "6.0.4",
-              "from": "glob@>=6.0.0 <6.1.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "version": "7.1.2",
+              "from": "glob@>=7.0.0 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
               "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                },
                 "inflight": {
                   "version": "1.0.6",
                   "from": "inflight@>=1.0.4 <2.0.0",
@@ -510,7 +498,7 @@
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "from": "minimatch@>=3.0.4 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "dependencies": {
                     "brace-expansion": {
@@ -551,15 +539,10 @@
                 }
               }
             },
-            "lodash": {
-              "version": "3.10.1",
-              "from": "lodash@>=3.10.0 <3.11.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            },
             "readable-stream": {
-              "version": "2.0.6",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "version": "2.3.3",
+              "from": "readable-stream@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
@@ -568,7 +551,7 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@>=2.0.3 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
@@ -581,10 +564,15 @@
                   "from": "process-nextick-args@>=1.0.6 <1.1.0",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
+                "safe-buffer": {
+                  "version": "5.1.1",
+                  "from": "safe-buffer@>=5.1.1 <5.2.0",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                },
                 "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "version": "1.0.3",
+                  "from": "string_decoder@>=1.0.3 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
@@ -594,9 +582,9 @@
               }
             },
             "tar-stream": {
-              "version": "1.3.2",
-              "from": "tar-stream@>=1.3.1 <1.4.0",
-              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.3.2.tgz",
+              "version": "1.5.4",
+              "from": "tar-stream@>=1.5.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
               "dependencies": {
                 "bl": {
                   "version": "1.2.1",
@@ -630,33 +618,47 @@
               }
             },
             "zip-stream": {
-              "version": "0.8.0",
-              "from": "zip-stream@>=0.8.0 <0.9.0",
-              "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.8.0.tgz",
+              "version": "1.2.0",
+              "from": "zip-stream@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
               "dependencies": {
                 "compress-commons": {
-                  "version": "0.4.2",
-                  "from": "compress-commons@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.4.2.tgz",
+                  "version": "1.2.0",
+                  "from": "compress-commons@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
                   "dependencies": {
                     "crc32-stream": {
-                      "version": "0.4.0",
-                      "from": "crc32-stream@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.4.0.tgz"
-                    },
-                    "node-int64": {
-                      "version": "0.4.0",
-                      "from": "node-int64@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
+                      "version": "2.0.0",
+                      "from": "crc32-stream@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+                      "dependencies": {
+                        "crc": {
+                          "version": "3.4.4",
+                          "from": "crc@>=3.4.4 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz"
+                        }
+                      }
                     },
                     "normalize-path": {
-                      "version": "2.0.1",
-                      "from": "normalize-path@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                      "version": "2.1.1",
+                      "from": "normalize-path@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                      "dependencies": {
+                        "remove-trailing-separator": {
+                          "version": "1.0.2",
+                          "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+                        }
+                      }
                     }
                   }
                 }
               }
+            },
+            "walkdir": {
+              "version": "0.0.11",
+              "from": "walkdir@>=0.0.11 <0.0.12",
+              "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz"
             }
           }
         },
@@ -707,21 +709,598 @@
           }
         },
         "pretty-bytes": {
-          "version": "3.0.1",
-          "from": "pretty-bytes@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
-          "dependencies": {
-            "number-is-nan": {
-              "version": "1.0.1",
-              "from": "number-is-nan@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-            }
-          }
+          "version": "4.0.2",
+          "from": "pretty-bytes@>=4.0.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz"
         },
         "stream-buffers": {
           "version": "2.2.0",
           "from": "stream-buffers@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz"
+        },
+        "iltorb": {
+          "version": "1.3.4",
+          "from": "iltorb@>=1.0.13 <2.0.0",
+          "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-1.3.4.tgz",
+          "dependencies": {
+            "nan": {
+              "version": "2.6.2",
+              "from": "nan@>=2.6.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
+            },
+            "node-pre-gyp": {
+              "version": "0.6.36",
+              "from": "node-pre-gyp@0.6.36",
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz"
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "from": "ajv@4.11.8",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
+            },
+            "abbrev": {
+              "version": "1.1.0",
+              "from": "abbrev@1.1.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "from": "asn1@0.2.3",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "from": "ansi-regex@2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            },
+            "aproba": {
+              "version": "1.1.2",
+              "from": "aproba@1.1.2",
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz"
+            },
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "aws-sign2@0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "from": "are-we-there-yet@1.1.4",
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz"
+            },
+            "assert-plus": {
+              "version": "0.2.0",
+              "from": "assert-plus@0.2.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "from": "asynckit@0.4.0",
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "from": "aws4@1.6.0",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "from": "bcrypt-pbkdf@1.0.1",
+              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+            },
+            "brace-expansion": {
+              "version": "1.1.8",
+              "from": "brace-expansion@1.1.8",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "from": "balanced-match@1.0.0",
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+            },
+            "block-stream": {
+              "version": "0.0.9",
+              "from": "block-stream@0.0.9",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "from": "caseless@0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+            },
+            "boom": {
+              "version": "2.10.1",
+              "from": "boom@2.10.1",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "from": "code-point-at@1.1.0",
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "combined-stream@1.0.5",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+            },
+            "co": {
+              "version": "4.6.0",
+              "from": "co@4.6.0",
+              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "from": "console-control-strings@1.1.0",
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "from": "concat-map@0.0.1",
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "from": "core-util-is@1.0.2",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+            },
+            "cryptiles": {
+              "version": "2.0.5",
+              "from": "cryptiles@2.0.5",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "from": "delayed-stream@1.0.0",
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+            },
+            "debug": {
+              "version": "2.6.8",
+              "from": "debug@2.6.8",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
+            },
+            "deep-extend": {
+              "version": "0.4.2",
+              "from": "deep-extend@0.4.2",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "from": "delegates@1.0.0",
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+            },
+            "extsprintf": {
+              "version": "1.0.2",
+              "from": "extsprintf@1.0.2",
+              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "from": "ecc-jsbn@0.1.1",
+              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "from": "forever-agent@0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "from": "fs.realpath@1.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "from": "form-data@2.1.4",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
+            },
+            "fstream-ignore": {
+              "version": "1.0.5",
+              "from": "fstream-ignore@1.0.5",
+              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
+            },
+            "extend": {
+              "version": "3.0.1",
+              "from": "extend@3.0.1",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+            },
+            "glob": {
+              "version": "7.1.2",
+              "from": "glob@7.1.2",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "from": "har-validator@4.2.1",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
+            },
+            "har-schema": {
+              "version": "1.0.5",
+              "from": "har-schema@1.0.5",
+              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "from": "gauge@2.7.4",
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz"
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "from": "graceful-fs@4.1.11",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "from": "has-unicode@2.0.1",
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "from": "hawk@3.1.3",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+            },
+            "fstream": {
+              "version": "1.0.11",
+              "from": "fstream@1.0.11",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "from": "http-signature@1.1.1",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "from": "inflight@1.0.6",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+            },
+            "hoek": {
+              "version": "2.16.3",
+              "from": "hoek@2.16.3",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "from": "is-fullwidth-code-point@1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+            },
+            "ini": {
+              "version": "1.3.4",
+              "from": "ini@1.3.4",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "from": "is-typedarray@1.0.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "from": "jsbn@0.1.1",
+              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "from": "json-schema@0.2.3",
+              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "jsonify@0.0.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "json-stringify-safe@5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-db": {
+              "version": "1.27.0",
+              "from": "mime-db@1.27.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "from": "json-stable-stringify@1.0.1",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "from": "minimatch@3.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.15",
+              "from": "mime-types@2.1.15",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+            },
+            "ms": {
+              "version": "2.0.0",
+              "from": "ms@2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "from": "number-is-nan@1.0.1",
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+            },
+            "npmlog": {
+              "version": "4.1.0",
+              "from": "npmlog@4.1.0",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz"
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "from": "oauth-sign@0.8.2",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+            },
+            "once": {
+              "version": "1.4.0",
+              "from": "once@1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "from": "os-homedir@1.0.2",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "path-is-absolute@1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "from": "os-tmpdir@1.0.2",
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "object-assign@4.1.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "from": "osenv@0.1.4",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "from": "performance-now@0.2.0",
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+            },
+            "readable-stream": {
+              "version": "2.3.1",
+              "from": "readable-stream@2.3.1",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz"
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "from": "process-nextick-args@1.0.7",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+            },
+            "qs": {
+              "version": "6.4.0",
+              "from": "qs@6.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "from": "punycode@1.4.1",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "from": "set-blocking@2.0.0",
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "from": "safe-buffer@5.1.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+            },
+            "request": {
+              "version": "2.81.0",
+              "from": "request@2.81.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "from": "sntp@1.0.9",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "from": "string-width@1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "stringstream@0.0.5",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "from": "signal-exit@3.0.2",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "from": "strip-json-comments@2.0.1",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+            },
+            "tar-pack": {
+              "version": "3.4.0",
+              "from": "tar-pack@3.4.0",
+              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "from": "tunnel-agent@0.6.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "from": "tough-cookie@2.3.2",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "from": "tweetnacl@0.14.5",
+              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+            },
+            "tar": {
+              "version": "2.2.1",
+              "from": "tar@2.2.1",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "from": "util-deprecate@1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "from": "uid-number@0.0.6",
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "from": "wrappy@1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            },
+            "verror": {
+              "version": "1.3.6",
+              "from": "verror@1.3.6",
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "from": "wide-align@1.1.2",
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "from": "nopt@4.0.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz"
+            },
+            "semver": {
+              "version": "5.3.0",
+              "from": "semver@5.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.6.1",
+              "from": "rimraf@2.6.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "from": "uuid@3.1.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "from": "dashdash@1.14.1",
+              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                }
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "from": "getpass@0.1.7",
+              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                }
+              }
+            },
+            "jsprim": {
+              "version": "1.4.0",
+              "from": "jsprim@1.4.0",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.2",
+              "from": "string_decoder@1.0.2",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.0.1",
+                  "from": "safe-buffer@5.0.1",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                }
+              }
+            },
+            "rc": {
+              "version": "1.2.1",
+              "from": "rc@1.2.1",
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@1.2.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                }
+              }
+            },
+            "sshpk": {
+              "version": "1.13.1",
+              "from": "sshpk@1.13.1",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -732,7 +1311,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -742,7 +1321,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -790,7 +1369,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -800,7 +1379,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -1019,7 +1598,7 @@
             "strip-json-comments": {
               "version": "1.0.4",
               "from": "strip-json-comments@>=1.0.0 <1.1.0",
-              "resolved": "http://npm.skunkhenry.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "lodash": {
               "version": "3.7.0",
@@ -1210,16 +1789,9 @@
                               }
                             },
                             "commander": {
-                              "version": "2.10.0",
+                              "version": "2.11.0",
                               "from": "commander@>=2.9.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
-                              "dependencies": {
-                                "graceful-readlink": {
-                                  "version": "1.0.1",
-                                  "from": "graceful-readlink@>=1.0.0",
-                                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                                }
-                              }
+                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
                             },
                             "is-my-json-valid": {
                               "version": "2.16.0",
@@ -1574,9 +2146,9 @@
                   "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
                 },
                 "js-yaml": {
-                  "version": "3.8.4",
+                  "version": "3.9.0",
                   "from": "js-yaml@>=3.3.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "1.0.9",
@@ -1591,9 +2163,9 @@
                       }
                     },
                     "esprima": {
-                      "version": "3.1.3",
-                      "from": "esprima@>=3.1.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+                      "version": "4.0.0",
+                      "from": "esprima@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
                     }
                   }
                 },
@@ -1780,11 +2352,6 @@
                       "from": "ansi-styles@>=2.2.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
-                    "arr-diff": {
-                      "version": "2.0.0",
-                      "from": "arr-diff@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
-                    },
                     "append-transform": {
                       "version": "0.3.0",
                       "from": "append-transform@>=0.3.0 <0.4.0",
@@ -1810,15 +2377,15 @@
                       "from": "babel-code-frame@>=6.8.0 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz"
                     },
+                    "arr-diff": {
+                      "version": "2.0.0",
+                      "from": "arr-diff@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
+                    },
                     "babel-messages": {
                       "version": "6.8.0",
                       "from": "babel-messages@>=6.8.0 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                    },
-                    "babel-generator": {
-                      "version": "6.11.4",
-                      "from": "babel-generator@>=6.11.3 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.11.4.tgz"
                     },
                     "babel-runtime": {
                       "version": "6.9.2",
@@ -1839,6 +2406,11 @@
                       "version": "6.11.1",
                       "from": "babel-types@>=6.10.2 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.11.1.tgz"
+                    },
+                    "babel-generator": {
+                      "version": "6.11.4",
+                      "from": "babel-generator@>=6.11.3 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.11.4.tgz"
                     },
                     "babylon": {
                       "version": "6.8.4",
@@ -1870,20 +2442,25 @@
                       "from": "camelcase@>=1.0.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
-                    "center-align": {
-                      "version": "0.1.3",
-                      "from": "center-align@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
-                    },
                     "chalk": {
                       "version": "1.1.3",
                       "from": "chalk@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
                     },
+                    "center-align": {
+                      "version": "0.1.3",
+                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
+                    },
                     "code-point-at": {
                       "version": "1.0.0",
                       "from": "code-point-at@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
+                    },
+                    "core-js": {
+                      "version": "2.4.1",
+                      "from": "core-js@>=2.4.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                     },
                     "commondir": {
                       "version": "1.0.1",
@@ -1894,11 +2471,6 @@
                       "version": "0.0.1",
                       "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    },
-                    "core-js": {
-                      "version": "2.4.1",
-                      "from": "core-js@>=2.4.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                     },
                     "cross-spawn": {
                       "version": "4.0.0",
@@ -1940,15 +2512,20 @@
                       "from": "expand-range@>=1.8.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
                     },
+                    "filename-regex": {
+                      "version": "2.0.0",
+                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                    },
                     "extglob": {
                       "version": "0.3.2",
                       "from": "extglob@>=0.3.1 <0.4.0",
                       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
                     },
-                    "filename-regex": {
-                      "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                    "for-own": {
+                      "version": "0.1.4",
+                      "from": "for-own@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
                     },
                     "fill-range": {
                       "version": "2.2.3",
@@ -1960,35 +2537,25 @@
                       "from": "for-in@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
                     },
-                    "for-own": {
-                      "version": "0.1.4",
-                      "from": "for-own@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
-                    },
                     "fs.realpath": {
                       "version": "1.0.0",
                       "from": "fs.realpath@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-                    },
-                    "get-caller-file": {
-                      "version": "1.0.1",
-                      "from": "get-caller-file@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.1.tgz"
                     },
                     "get-stdin": {
                       "version": "4.0.1",
                       "from": "get-stdin@>=4.0.1 <5.0.0",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     },
-                    "glob-base": {
-                      "version": "0.3.0",
-                      "from": "glob-base@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
-                    },
                     "glob-parent": {
                       "version": "2.0.0",
                       "from": "glob-parent@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                    },
+                    "glob-base": {
+                      "version": "0.3.0",
+                      "from": "glob-base@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                     },
                     "globals": {
                       "version": "8.18.0",
@@ -2005,25 +2572,25 @@
                       "from": "has-ansi@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                     },
-                    "has-flag": {
-                      "version": "1.0.0",
-                      "from": "has-flag@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                    "get-caller-file": {
+                      "version": "1.0.1",
+                      "from": "get-caller-file@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.1.tgz"
                     },
                     "hosted-git-info": {
                       "version": "2.1.5",
                       "from": "hosted-git-info@>=2.1.4 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
                     },
+                    "has-flag": {
+                      "version": "1.0.0",
+                      "from": "has-flag@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                    },
                     "imurmurhash": {
                       "version": "0.1.4",
                       "from": "imurmurhash@>=0.1.4 <0.2.0",
                       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-                    },
-                    "inflight": {
-                      "version": "1.0.5",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
@@ -2035,30 +2602,30 @@
                       "from": "invariant@>=2.2.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
                     },
-                    "invert-kv": {
-                      "version": "1.0.0",
-                      "from": "invert-kv@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-                    },
-                    "is-arrayish": {
-                      "version": "0.2.1",
-                      "from": "is-arrayish@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                    },
-                    "is-buffer": {
-                      "version": "1.1.3",
-                      "from": "is-buffer@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                    "inflight": {
+                      "version": "1.0.5",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
                       "from": "is-builtin-module@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
                     },
+                    "invert-kv": {
+                      "version": "1.0.0",
+                      "from": "invert-kv@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                    },
                     "is-dotfile": {
                       "version": "1.0.2",
                       "from": "is-dotfile@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                    },
+                    "is-arrayish": {
+                      "version": "0.2.1",
+                      "from": "is-arrayish@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                     },
                     "is-equal-shallow": {
                       "version": "0.1.3",
@@ -2070,6 +2637,11 @@
                       "from": "is-extendable@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                     },
+                    "is-buffer": {
+                      "version": "1.1.3",
+                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                    },
                     "is-extglob": {
                       "version": "1.0.0",
                       "from": "is-extglob@>=1.0.0 <2.0.0",
@@ -2079,11 +2651,6 @@
                       "version": "1.0.1",
                       "from": "is-finite@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
                     },
                     "is-glob": {
                       "version": "2.0.1",
@@ -2095,11 +2662,6 @@
                       "from": "is-number@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                     },
-                    "is-posix-bracket": {
-                      "version": "0.1.1",
-                      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-                    },
                     "is-primitive": {
                       "version": "2.0.0",
                       "from": "is-primitive@>=2.0.0 <3.0.0",
@@ -2110,10 +2672,15 @@
                       "from": "is-utf8@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                     },
-                    "isarray": {
+                    "is-posix-bracket": {
+                      "version": "0.1.1",
+                      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                    },
+                    "is-fullwidth-code-point": {
                       "version": "1.0.0",
-                      "from": "isarray@1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
                     },
                     "isexe": {
                       "version": "1.1.2",
@@ -2125,6 +2692,11 @@
                       "from": "isobject@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
                     },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@1.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
                     "js-tokens": {
                       "version": "2.0.0",
                       "from": "js-tokens@>=2.0.0 <3.0.0",
@@ -2135,25 +2707,25 @@
                       "from": "kind-of@>=3.0.2 <4.0.0",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz"
                     },
-                    "lazy-cache": {
-                      "version": "1.0.4",
-                      "from": "lazy-cache@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-                    },
                     "lcid": {
                       "version": "1.0.0",
                       "from": "lcid@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
                     },
-                    "load-json-file": {
-                      "version": "1.1.0",
-                      "from": "load-json-file@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
+                    "lazy-cache": {
+                      "version": "1.0.4",
+                      "from": "lazy-cache@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                     },
                     "lodash": {
                       "version": "4.13.1",
                       "from": "lodash@>=4.2.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+                    },
+                    "load-json-file": {
+                      "version": "1.1.0",
+                      "from": "load-json-file@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
                     },
                     "lodash.assign": {
                       "version": "4.0.9",
@@ -2200,20 +2772,15 @@
                       "from": "ms@0.7.1",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
-                    "normalize-package-data": {
-                      "version": "2.3.5",
-                      "from": "normalize-package-data@>=2.3.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
-                    },
                     "normalize-path": {
                       "version": "2.0.1",
                       "from": "normalize-path@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                     },
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    "normalize-package-data": {
+                      "version": "2.3.5",
+                      "from": "normalize-package-data@>=2.3.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
                     },
                     "object.omit": {
                       "version": "2.0.0",
@@ -2245,35 +2812,35 @@
                       "from": "parse-glob@>=3.0.4 <4.0.0",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
                     },
-                    "parse-json": {
-                      "version": "2.2.0",
-                      "from": "parse-json@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
-                    },
-                    "path-exists": {
-                      "version": "2.1.0",
-                      "from": "path-exists@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
                       "from": "path-is-absolute@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     },
+                    "parse-json": {
+                      "version": "2.2.0",
+                      "from": "parse-json@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
+                    },
                     "path-parse": {
                       "version": "1.0.5",
                       "from": "path-parse@>=1.0.5 <2.0.0",
                       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
                     },
-                    "path-type": {
-                      "version": "1.1.0",
-                      "from": "path-type@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
-                    },
                     "pify": {
                       "version": "2.3.0",
                       "from": "pify@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                    },
+                    "path-type": {
+                      "version": "1.1.0",
+                      "from": "path-type@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
                     },
                     "pinkie": {
                       "version": "2.0.4",
@@ -2284,6 +2851,11 @@
                       "version": "2.0.1",
                       "from": "pinkie-promise@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+                    },
+                    "path-exists": {
+                      "version": "2.1.0",
+                      "from": "path-exists@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                     },
                     "pkg-dir": {
                       "version": "1.0.0",
@@ -2310,15 +2882,15 @@
                       "from": "read-pkg@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
                     },
-                    "read-pkg-up": {
-                      "version": "1.0.1",
-                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
-                    },
                     "regenerator-runtime": {
                       "version": "0.9.5",
                       "from": "regenerator-runtime@>=0.9.5 <0.10.0",
                       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
+                    },
+                    "read-pkg-up": {
+                      "version": "1.0.1",
+                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
                     },
                     "regex-cache": {
                       "version": "0.4.3",
@@ -2345,15 +2917,15 @@
                       "from": "require-directory@>=2.1.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
                     },
-                    "require-main-filename": {
-                      "version": "1.0.1",
-                      "from": "require-main-filename@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
-                    },
                     "right-align": {
                       "version": "0.1.3",
                       "from": "right-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+                    },
+                    "require-main-filename": {
+                      "version": "1.0.1",
+                      "from": "require-main-filename@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
                     },
                     "semver": {
                       "version": "5.3.0",
@@ -2365,15 +2937,15 @@
                       "from": "set-blocking@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
                     },
-                    "slide": {
-                      "version": "1.1.6",
-                      "from": "slide@>=1.1.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-                    },
                     "source-map": {
                       "version": "0.5.6",
                       "from": "source-map@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                    },
+                    "slide": {
+                      "version": "1.1.6",
+                      "from": "slide@>=1.1.5 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
                     },
                     "spdx-correct": {
                       "version": "1.0.2",
@@ -2389,11 +2961,6 @@
                       "version": "1.0.2",
                       "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
-                    },
-                    "spdx-license-ids": {
-                      "version": "1.2.1",
-                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                     },
                     "string-width": {
                       "version": "1.0.1",
@@ -2414,6 +2981,11 @@
                       "version": "2.0.0",
                       "from": "supports-color@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    },
+                    "spdx-license-ids": {
+                      "version": "1.2.1",
+                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.2",
@@ -2450,25 +3022,25 @@
                       "from": "wordwrap@>=0.0.2 <0.1.0",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     },
-                    "wrap-ansi": {
-                      "version": "2.0.0",
-                      "from": "wrap-ansi@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
-                    },
                     "wrappy": {
                       "version": "1.0.2",
                       "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     },
-                    "write-file-atomic": {
-                      "version": "1.1.4",
-                      "from": "write-file-atomic@>=1.1.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz"
+                    "wrap-ansi": {
+                      "version": "2.0.0",
+                      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
                     },
                     "y18n": {
                       "version": "3.2.1",
                       "from": "y18n@>=3.2.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+                    },
+                    "write-file-atomic": {
+                      "version": "1.1.4",
+                      "from": "write-file-atomic@>=1.1.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz"
                     },
                     "yallist": {
                       "version": "2.0.0",
@@ -2693,7 +3265,7 @@
         "ini": {
           "version": "1.3.4",
           "from": "ini@>=1.3.0 <1.4.0",
-          "resolved": "http://npm.skunkhenry.com/ini/-/ini-1.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
         },
         "lodash": {
           "version": "2.4.2",
@@ -2709,7 +3281,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -2719,7 +3291,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -2771,7 +3343,7 @@
                 "typedarray": {
                   "version": "0.0.6",
                   "from": "typedarray@>=0.0.6 <0.0.7",
-                  "resolved": "http://npm.skunkhenry.com/typedarray/-/typedarray-0.0.6.tgz"
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "2.3.3",
@@ -2847,9 +3419,9 @@
                   "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
                 },
                 "es5-ext": {
-                  "version": "0.10.23",
+                  "version": "0.10.24",
                   "from": "es5-ext@>=0.10.14 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz"
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz"
                 },
                 "es6-iterator": {
                   "version": "2.0.1",
@@ -2889,9 +3461,9 @@
                       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
                     },
                     "es5-ext": {
-                      "version": "0.10.23",
+                      "version": "0.10.24",
                       "from": "es5-ext@>=0.10.14 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz"
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz"
                     },
                     "es6-iterator": {
                       "version": "2.0.1",
@@ -2925,9 +3497,9 @@
               "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "5.0.3",
+                  "version": "5.1.1",
                   "from": "acorn@>=5.0.1 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz"
                 },
                 "acorn-jsx": {
                   "version": "3.0.1",
@@ -3211,7 +3783,7 @@
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
                       "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "http://npm.skunkhenry.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
@@ -3254,7 +3826,7 @@
                 "string-width": {
                   "version": "1.0.2",
                   "from": "string-width@>=1.0.1 <2.0.0",
-                  "resolved": "http://npm.skunkhenry.com/string-width/-/string-width-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
@@ -3264,7 +3836,7 @@
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
                       "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "http://npm.skunkhenry.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
@@ -3334,9 +3906,9 @@
               }
             },
             "js-yaml": {
-              "version": "3.8.4",
+              "version": "3.9.0",
               "from": "js-yaml@>=3.5.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.9",
@@ -3351,9 +3923,9 @@
                   }
                 },
                 "esprima": {
-                  "version": "3.1.3",
-                  "from": "esprima@>=3.1.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+                  "version": "4.0.0",
+                  "from": "esprima@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
                 }
               }
             },
@@ -3482,7 +4054,7 @@
             "strip-json-comments": {
               "version": "1.0.4",
               "from": "strip-json-comments@>=1.0.1 <1.1.0",
-              "resolved": "http://npm.skunkhenry.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "table": {
               "version": "3.8.3",
@@ -3545,7 +4117,7 @@
             "user-home": {
               "version": "2.0.0",
               "from": "user-home@>=2.0.0 <3.0.0",
-              "resolved": "http://npm.skunkhenry.com/user-home/-/user-home-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
@@ -3565,7 +4137,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -3575,7 +4147,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -3712,7 +4284,7 @@
         "glob": {
           "version": "5.0.15",
           "from": "glob@>=5.0.15 <6.0.0",
-          "resolved": "http://npm.skunkhenry.com/glob/-/glob-5.0.15.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.6",
@@ -3770,7 +4342,7 @@
             "optimist": {
               "version": "0.6.1",
               "from": "optimist@>=0.6.1 <0.7.0",
-              "resolved": "http://npm.skunkhenry.com/optimist/-/optimist-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.3",
@@ -3780,7 +4352,7 @@
                 "minimist": {
                   "version": "0.0.10",
                   "from": "minimist@>=0.0.1 <0.1.0",
-                  "resolved": "http://npm.skunkhenry.com/minimist/-/minimist-0.0.10.tgz"
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 }
               }
             },
@@ -3814,22 +4386,22 @@
                     "camelcase": {
                       "version": "1.2.1",
                       "from": "camelcase@>=1.0.2 <2.0.0",
-                      "resolved": "http://npm.skunkhenry.com/camelcase/-/camelcase-1.2.1.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "cliui": {
                       "version": "2.1.0",
                       "from": "cliui@>=2.1.0 <3.0.0",
-                      "resolved": "http://npm.skunkhenry.com/cliui/-/cliui-2.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.3",
                           "from": "center-align@>=0.1.1 <0.2.0",
-                          "resolved": "http://npm.skunkhenry.com/center-align/-/center-align-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
                               "from": "align-text@>=0.1.3 <0.2.0",
-                              "resolved": "http://npm.skunkhenry.com/align-text/-/align-text-0.1.4.tgz",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "3.2.2",
@@ -3846,7 +4418,7 @@
                                 "longest": {
                                   "version": "1.0.1",
                                   "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "http://npm.skunkhenry.com/longest/-/longest-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.6.1",
@@ -3858,19 +4430,19 @@
                             "lazy-cache": {
                               "version": "1.0.4",
                               "from": "lazy-cache@>=1.0.3 <2.0.0",
-                              "resolved": "http://npm.skunkhenry.com/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                             }
                           }
                         },
                         "right-align": {
                           "version": "0.1.3",
                           "from": "right-align@>=0.1.1 <0.2.0",
-                          "resolved": "http://npm.skunkhenry.com/right-align/-/right-align-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
                               "from": "align-text@>=0.1.3 <0.2.0",
-                              "resolved": "http://npm.skunkhenry.com/align-text/-/align-text-0.1.4.tgz",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "3.2.2",
@@ -3887,7 +4459,7 @@
                                 "longest": {
                                   "version": "1.0.1",
                                   "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "http://npm.skunkhenry.com/longest/-/longest-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.6.1",
@@ -3901,7 +4473,7 @@
                         "wordwrap": {
                           "version": "0.0.2",
                           "from": "wordwrap@0.0.2",
-                          "resolved": "http://npm.skunkhenry.com/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
                     },
@@ -3927,9 +4499,9 @@
           }
         },
         "js-yaml": {
-          "version": "3.8.4",
+          "version": "3.9.0",
           "from": "js-yaml@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
           "dependencies": {
             "argparse": {
               "version": "1.0.9",
@@ -3944,9 +4516,9 @@
               }
             },
             "esprima": {
-              "version": "3.1.3",
-              "from": "esprima@>=3.1.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+              "version": "4.0.0",
+              "from": "esprima@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
             }
           }
         },
@@ -4027,7 +4599,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -4037,7 +4609,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -4090,7 +4662,7 @@
           "dependencies": {
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "object-assign": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,3271 +2,765 @@
   "name": "grunt-fh-build",
   "version": "2.0.0",
   "dependencies": {
-    "findup-sync": {
-      "version": "0.4.3",
-      "from": "findup-sync@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+    "abbrev": {
+      "version": "1.0.9",
+      "from": "abbrev@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+    },
+    "acorn": {
+      "version": "5.1.1",
+      "from": "acorn@>=5.0.1 <6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz"
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "from": "acorn-jsx@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "dependencies": {
-        "detect-file": {
-          "version": "0.1.0",
-          "from": "detect-file@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
-          "dependencies": {
-            "fs-exists-sync": {
-              "version": "0.1.0",
-              "from": "fs-exists-sync@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
-            }
-          }
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "from": "is-glob@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "dependencies": {
-            "is-extglob": {
-              "version": "1.0.0",
-              "from": "is-extglob@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-            }
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "from": "micromatch@>=2.3.7 <3.0.0",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "dependencies": {
-            "arr-diff": {
-              "version": "2.0.0",
-              "from": "arr-diff@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-              "dependencies": {
-                "arr-flatten": {
-                  "version": "1.1.0",
-                  "from": "arr-flatten@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
-                }
-              }
-            },
-            "array-unique": {
-              "version": "0.2.1",
-              "from": "array-unique@>=0.2.1 <0.3.0",
-              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-            },
-            "braces": {
-              "version": "1.8.5",
-              "from": "braces@>=1.8.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-              "dependencies": {
-                "expand-range": {
-                  "version": "1.8.2",
-                  "from": "expand-range@>=1.8.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                  "dependencies": {
-                    "fill-range": {
-                      "version": "2.2.3",
-                      "from": "fill-range@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                      "dependencies": {
-                        "is-number": {
-                          "version": "2.1.0",
-                          "from": "is-number@>=2.1.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
-                        },
-                        "isobject": {
-                          "version": "2.1.0",
-                          "from": "isobject@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                          "dependencies": {
-                            "isarray": {
-                              "version": "1.0.0",
-                              "from": "isarray@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "randomatic": {
-                          "version": "1.1.7",
-                          "from": "randomatic@>=1.1.3 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-                          "dependencies": {
-                            "is-number": {
-                              "version": "3.0.0",
-                              "from": "is-number@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.2.2",
-                                  "from": "kind-of@>=3.0.2 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.5",
-                                      "from": "is-buffer@>=1.1.5 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "kind-of": {
-                              "version": "4.0.0",
-                              "from": "kind-of@>=4.0.0 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.5",
-                                  "from": "is-buffer@>=1.1.5 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "repeat-string": {
-                          "version": "1.6.1",
-                          "from": "repeat-string@>=1.5.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "preserve": {
-                  "version": "0.2.0",
-                  "from": "preserve@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
-                },
-                "repeat-element": {
-                  "version": "1.1.2",
-                  "from": "repeat-element@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-                }
-              }
-            },
-            "expand-brackets": {
-              "version": "0.1.5",
-              "from": "expand-brackets@>=0.1.4 <0.2.0",
-              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-              "dependencies": {
-                "is-posix-bracket": {
-                  "version": "0.1.1",
-                  "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-                }
-              }
-            },
-            "extglob": {
-              "version": "0.3.2",
-              "from": "extglob@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
-            },
-            "filename-regex": {
-              "version": "2.0.1",
-              "from": "filename-regex@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
-            },
-            "is-extglob": {
-              "version": "1.0.0",
-              "from": "is-extglob@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-            },
-            "kind-of": {
-              "version": "3.2.2",
-              "from": "kind-of@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "dependencies": {
-                "is-buffer": {
-                  "version": "1.1.5",
-                  "from": "is-buffer@>=1.1.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                }
-              }
-            },
-            "normalize-path": {
-              "version": "2.1.1",
-              "from": "normalize-path@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-              "dependencies": {
-                "remove-trailing-separator": {
-                  "version": "1.0.2",
-                  "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
-                }
-              }
-            },
-            "object.omit": {
-              "version": "2.0.1",
-              "from": "object.omit@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-              "dependencies": {
-                "for-own": {
-                  "version": "0.1.5",
-                  "from": "for-own@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-                  "dependencies": {
-                    "for-in": {
-                      "version": "1.0.2",
-                      "from": "for-in@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
-                    }
-                  }
-                },
-                "is-extendable": {
-                  "version": "0.1.1",
-                  "from": "is-extendable@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-                }
-              }
-            },
-            "parse-glob": {
-              "version": "3.0.4",
-              "from": "parse-glob@>=3.0.4 <4.0.0",
-              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-              "dependencies": {
-                "glob-base": {
-                  "version": "0.3.0",
-                  "from": "glob-base@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                  "dependencies": {
-                    "glob-parent": {
-                      "version": "2.0.0",
-                      "from": "glob-parent@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
-                    }
-                  }
-                },
-                "is-dotfile": {
-                  "version": "1.0.3",
-                  "from": "is-dotfile@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
-                }
-              }
-            },
-            "regex-cache": {
-              "version": "0.4.3",
-              "from": "regex-cache@>=0.4.2 <0.5.0",
-              "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-              "dependencies": {
-                "is-equal-shallow": {
-                  "version": "0.1.3",
-                  "from": "is-equal-shallow@>=0.1.3 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
-                },
-                "is-primitive": {
-                  "version": "2.0.0",
-                  "from": "is-primitive@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "resolve-dir": {
-          "version": "0.1.1",
-          "from": "resolve-dir@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-          "dependencies": {
-            "expand-tilde": {
-              "version": "1.2.2",
-              "from": "expand-tilde@>=1.2.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "from": "os-homedir@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-                }
-              }
-            },
-            "global-modules": {
-              "version": "0.2.3",
-              "from": "global-modules@>=0.2.3 <0.3.0",
-              "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-              "dependencies": {
-                "global-prefix": {
-                  "version": "0.1.5",
-                  "from": "global-prefix@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-                  "dependencies": {
-                    "homedir-polyfill": {
-                      "version": "1.0.1",
-                      "from": "homedir-polyfill@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-                      "dependencies": {
-                        "parse-passwd": {
-                          "version": "1.0.0",
-                          "from": "parse-passwd@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "ini": {
-                      "version": "1.3.4",
-                      "from": "ini@>=1.3.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                    },
-                    "which": {
-                      "version": "1.2.14",
-                      "from": "which@>=1.2.12 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-                      "dependencies": {
-                        "isexe": {
-                          "version": "2.0.0",
-                          "from": "isexe@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "is-windows": {
-                  "version": "0.2.0",
-                  "from": "is-windows@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
-                }
-              }
-            }
-          }
+        "acorn": {
+          "version": "3.3.0",
+          "from": "acorn@>=3.0.4 <4.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
         }
       }
     },
-    "grunt-contrib-clean": {
-      "version": "1.1.0",
-      "from": "grunt-contrib-clean@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz",
+    "ajv": {
+      "version": "4.11.8",
+      "from": "ajv@>=4.7.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
+    },
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "from": "ajv-keywords@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz"
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "from": "align-text@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "from": "amdefine@>=0.0.4",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "from": "ansi-escapes@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "from": "ansi-styles@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+    },
+    "archiver": {
+      "version": "1.3.0",
+      "from": "archiver@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "from": "rimraf@>=2.5.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "from": "glob@>=7.0.5 <8.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "dependencies": {
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "from": "fs.realpath@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-                },
-                "inflight": {
-                  "version": "1.0.6",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "from": "minimatch@>=3.0.4 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "from": "brace-expansion@>=1.1.7 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "from": "balanced-match@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                }
-              }
-            }
-          }
+          "version": "2.5.0",
+          "from": "async@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz"
         }
       }
+    },
+    "archiver-utils": {
+      "version": "1.3.0",
+      "from": "archiver-utils@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz"
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "from": "argparse@>=1.0.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz"
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "from": "arr-diff@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "from": "arr-flatten@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "from": "array-union@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz"
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "from": "array-uniq@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "from": "array-unique@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "from": "arrify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "from": "asn1@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "from": "assert-plus@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+    },
+    "async": {
+      "version": "1.5.2",
+      "from": "async@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "from": "asynckit@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "from": "aws-sign2@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "from": "aws4@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "from": "balanced-match@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "optional": true
+    },
+    "bl": {
+      "version": "1.2.1",
+      "from": "bl@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz"
+    },
+    "bluebird": {
+      "version": "3.5.0",
+      "from": "bluebird@>=3.3.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+    },
+    "boom": {
+      "version": "2.10.1",
+      "from": "boom@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "from": "brace-expansion@>=1.1.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+    },
+    "braces": {
+      "version": "1.8.5",
+      "from": "braces@>=1.8.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "from": "buffer-crc32@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "from": "caller-path@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz"
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "from": "callsites@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "from": "camelcase@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "optional": true
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "from": "caseless@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "from": "center-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "optional": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "from": "chalk@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+    },
+    "circular-json": {
+      "version": "0.3.1",
+      "from": "circular-json@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz"
+    },
+    "clean-yaml-object": {
+      "version": "0.1.0",
+      "from": "clean-yaml-object@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz"
+    },
+    "cli": {
+      "version": "1.0.1",
+      "from": "cli@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz"
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "from": "cli-cursor@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
+    },
+    "cli-width": {
+      "version": "2.1.0",
+      "from": "cli-width@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "from": "cliui@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "optional": true,
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "from": "wordwrap@0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "optional": true
+        }
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "from": "co@>=4.6.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "from": "code-point-at@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "from": "color-support@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz"
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "from": "combined-stream@>=1.0.5 <1.1.0",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+    },
+    "commander": {
+      "version": "2.11.0",
+      "from": "commander@>=2.9.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
+    },
+    "compress-commons": {
+      "version": "1.2.0",
+      "from": "compress-commons@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz"
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "from": "concat-map@0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "from": "concat-stream@>=1.4.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz"
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "from": "console-browserify@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+    },
+    "coveralls": {
+      "version": "2.13.1",
+      "from": "coveralls@>=2.11.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.6.1",
+          "from": "js-yaml@3.6.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz"
+        }
+      }
+    },
+    "crc": {
+      "version": "3.4.4",
+      "from": "crc@>=3.4.4 <4.0.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz"
+    },
+    "crc32-stream": {
+      "version": "2.0.0",
+      "from": "crc32-stream@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz"
+    },
+    "cross-spawn": {
+      "version": "4.0.2",
+      "from": "cross-spawn@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz"
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "from": "cryptiles@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+    },
+    "d": {
+      "version": "1.0.0",
+      "from": "d@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "from": "dashdash@>=1.12.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "from": "date-now@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+    },
+    "date-time": {
+      "version": "1.1.0",
+      "from": "date-time@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.1.0.tgz"
+    },
+    "debug": {
+      "version": "2.6.8",
+      "from": "debug@>=2.1.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "from": "decamelize@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "from": "deep-is@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+    },
+    "deeper": {
+      "version": "2.1.0",
+      "from": "deeper@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz"
+    },
+    "del": {
+      "version": "2.2.2",
+      "from": "del@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz"
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "from": "delayed-stream@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+    },
+    "detect-file": {
+      "version": "0.1.0",
+      "from": "detect-file@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz"
+    },
+    "diff": {
+      "version": "1.4.0",
+      "from": "diff@>=1.3.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+    },
+    "doctrine": {
+      "version": "1.5.0",
+      "from": "doctrine@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz"
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "from": "dom-serializer@>=0.0.0 <1.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "from": "domelementtype@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+        },
+        "entities": {
+          "version": "1.1.1",
+          "from": "entities@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "from": "domelementtype@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "from": "domhandler@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "from": "domutils@>=1.5.0 <1.6.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "optional": true
+    },
+    "end-of-stream": {
+      "version": "1.4.0",
+      "from": "end-of-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz"
+    },
+    "entities": {
+      "version": "1.0.0",
+      "from": "entities@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+    },
+    "es5-ext": {
+      "version": "0.10.24",
+      "from": "es5-ext@>=0.10.14 <0.11.0",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz"
+    },
+    "es6-iterator": {
+      "version": "2.0.1",
+      "from": "es6-iterator@>=2.0.1 <2.1.0",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "from": "es6-map@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz"
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "from": "es6-set@>=0.1.5 <0.2.0",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz"
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "from": "es6-symbol@>=3.1.1 <3.2.0",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "from": "es6-weak-map@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz"
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "from": "escodegen@>=1.8.0 <1.9.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "dependencies": {
+        "estraverse": {
+          "version": "1.9.3",
+          "from": "estraverse@>=1.9.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+        }
+      }
+    },
+    "escope": {
+      "version": "3.6.0",
+      "from": "escope@>=3.6.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz"
+    },
+    "eslint": {
+      "version": "2.13.1",
+      "from": "eslint@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "dependencies": {
+        "shelljs": {
+          "version": "0.6.1",
+          "from": "shelljs@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz"
+        }
+      }
+    },
+    "espree": {
+      "version": "3.4.3",
+      "from": "espree@>=3.1.6 <4.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz"
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "from": "esprima@>=2.6.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "from": "esrecurse@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz"
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "from": "estraverse@>=4.2.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "from": "esutils@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "from": "event-emitter@>=0.3.5 <0.4.0",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+    },
+    "events-to-array": {
+      "version": "1.1.2",
+      "from": "events-to-array@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz"
+    },
+    "exit": {
+      "version": "0.1.2",
+      "from": "exit@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "from": "exit-hook@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "from": "expand-brackets@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "from": "expand-range@>=1.8.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
+    },
+    "expand-tilde": {
+      "version": "1.2.2",
+      "from": "expand-tilde@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz"
+    },
+    "extend": {
+      "version": "3.0.1",
+      "from": "extend@>=3.0.0 <3.1.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "from": "extglob@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "from": "extsprintf@1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "from": "fast-levenshtein@>=2.0.4 <2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
+    },
+    "figures": {
+      "version": "1.7.0",
+      "from": "figures@>=1.3.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "from": "file-entry-cache@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz"
+    },
+    "file-sync-cmp": {
+      "version": "0.1.1",
+      "from": "file-sync-cmp@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz"
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "from": "filename-regex@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "from": "fill-range@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+    },
+    "findup-sync": {
+      "version": "0.4.3",
+      "from": "findup-sync@>=0.4.3 <0.5.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz"
+    },
+    "flat-cache": {
+      "version": "1.2.2",
+      "from": "flat-cache@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz"
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "from": "for-in@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "from": "for-own@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz"
+    },
+    "foreground-child": {
+      "version": "1.5.6",
+      "from": "foreground-child@>=1.3.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz"
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "from": "forever-agent@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "from": "form-data@>=2.1.1 <2.2.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
+    },
+    "fs-exists-sync": {
+      "version": "0.1.0",
+      "from": "fs-exists-sync@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "from": "fs.realpath@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "from": "generate-function@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "from": "generate-object-property@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "from": "getpass@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "from": "glob@>=7.0.5 <8.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "from": "glob-base@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "from": "glob-parent@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+    },
+    "global-modules": {
+      "version": "0.2.3",
+      "from": "global-modules@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
+    },
+    "global-prefix": {
+      "version": "0.1.5",
+      "from": "global-prefix@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz"
+    },
+    "globals": {
+      "version": "9.18.0",
+      "from": "globals@>=9.2.0 <10.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+    },
+    "globby": {
+      "version": "5.0.0",
+      "from": "globby@>=5.0.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz"
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "from": "graceful-fs@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+    },
+    "grunt-contrib-clean": {
+      "version": "1.1.0",
+      "from": "grunt-contrib-clean@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz"
     },
     "grunt-contrib-compress": {
       "version": "1.4.3",
       "from": "grunt-contrib-compress@>=1.4.3 <1.5.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.4.3.tgz",
-      "dependencies": {
-        "archiver": {
-          "version": "1.3.0",
-          "from": "archiver@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
-          "dependencies": {
-            "archiver-utils": {
-              "version": "1.3.0",
-              "from": "archiver-utils@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.11",
-                  "from": "graceful-fs@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                },
-                "lazystream": {
-                  "version": "1.0.0",
-                  "from": "lazystream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
-                },
-                "normalize-path": {
-                  "version": "2.1.1",
-                  "from": "normalize-path@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                  "dependencies": {
-                    "remove-trailing-separator": {
-                      "version": "1.0.2",
-                      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "async": {
-              "version": "2.5.0",
-              "from": "async@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz"
-            },
-            "buffer-crc32": {
-              "version": "0.2.13",
-              "from": "buffer-crc32@>=0.2.1 <0.3.0",
-              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
-            },
-            "glob": {
-              "version": "7.1.2",
-              "from": "glob@>=7.0.0 <8.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "dependencies": {
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "from": "fs.realpath@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-                },
-                "inflight": {
-                  "version": "1.0.6",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "from": "minimatch@>=3.0.4 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "from": "brace-expansion@>=1.1.7 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "from": "balanced-match@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "from": "readable-stream@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.3 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                },
-                "safe-buffer": {
-                  "version": "5.1.1",
-                  "from": "safe-buffer@>=5.1.1 <5.2.0",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "1.0.3",
-                  "from": "string_decoder@>=1.0.3 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "tar-stream": {
-              "version": "1.5.4",
-              "from": "tar-stream@>=1.5.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-              "dependencies": {
-                "bl": {
-                  "version": "1.2.1",
-                  "from": "bl@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz"
-                },
-                "end-of-stream": {
-                  "version": "1.4.0",
-                  "from": "end-of-stream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.4.0",
-                      "from": "once@>=1.4.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            },
-            "zip-stream": {
-              "version": "1.2.0",
-              "from": "zip-stream@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
-              "dependencies": {
-                "compress-commons": {
-                  "version": "1.2.0",
-                  "from": "compress-commons@>=1.2.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
-                  "dependencies": {
-                    "crc32-stream": {
-                      "version": "2.0.0",
-                      "from": "crc32-stream@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
-                      "dependencies": {
-                        "crc": {
-                          "version": "3.4.4",
-                          "from": "crc@>=3.4.4 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz"
-                        }
-                      }
-                    },
-                    "normalize-path": {
-                      "version": "2.1.1",
-                      "from": "normalize-path@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                      "dependencies": {
-                        "remove-trailing-separator": {
-                          "version": "1.0.2",
-                          "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "walkdir": {
-              "version": "0.0.11",
-              "from": "walkdir@>=0.0.11 <0.0.12",
-              "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz"
-            }
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "pretty-bytes": {
-          "version": "4.0.2",
-          "from": "pretty-bytes@>=4.0.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz"
-        },
-        "stream-buffers": {
-          "version": "2.2.0",
-          "from": "stream-buffers@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz"
-        },
-        "iltorb": {
-          "version": "1.3.4",
-          "from": "iltorb@>=1.0.13 <2.0.0",
-          "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-1.3.4.tgz",
-          "dependencies": {
-            "nan": {
-              "version": "2.6.2",
-              "from": "nan@>=2.6.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
-            },
-            "node-pre-gyp": {
-              "version": "0.6.36",
-              "from": "node-pre-gyp@0.6.36",
-              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz"
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "from": "ajv@4.11.8",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
-            },
-            "abbrev": {
-              "version": "1.1.0",
-              "from": "abbrev@1.1.0",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "from": "asn1@0.2.3",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "from": "ansi-regex@2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-            },
-            "aproba": {
-              "version": "1.1.2",
-              "from": "aproba@1.1.2",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz"
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "from": "are-we-there-yet@1.1.4",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz"
-            },
-            "assert-plus": {
-              "version": "0.2.0",
-              "from": "assert-plus@0.2.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "from": "asynckit@0.4.0",
-              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "from": "aws4@1.6.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "from": "bcrypt-pbkdf@1.0.1",
-              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "from": "brace-expansion@1.1.8",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "from": "balanced-match@1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "from": "block-stream@0.0.9",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "from": "caseless@0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
-            },
-            "boom": {
-              "version": "2.10.1",
-              "from": "boom@2.10.1",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "from": "code-point-at@1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "combined-stream@1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-            },
-            "co": {
-              "version": "4.6.0",
-              "from": "co@4.6.0",
-              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "from": "console-control-strings@1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "from": "concat-map@0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "from": "core-util-is@1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "from": "cryptiles@2.0.5",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "from": "delayed-stream@1.0.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-            },
-            "debug": {
-              "version": "2.6.8",
-              "from": "debug@2.6.8",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
-            },
-            "deep-extend": {
-              "version": "0.4.2",
-              "from": "deep-extend@0.4.2",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "from": "delegates@1.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-            },
-            "extsprintf": {
-              "version": "1.0.2",
-              "from": "extsprintf@1.0.2",
-              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "from": "ecc-jsbn@0.1.1",
-              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "from": "fs.realpath@1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "from": "form-data@2.1.4",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "from": "fstream-ignore@1.0.5",
-              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
-            },
-            "extend": {
-              "version": "3.0.1",
-              "from": "extend@3.0.1",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
-            },
-            "glob": {
-              "version": "7.1.2",
-              "from": "glob@7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "from": "har-validator@4.2.1",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
-            },
-            "har-schema": {
-              "version": "1.0.5",
-              "from": "har-schema@1.0.5",
-              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "from": "gauge@2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz"
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "from": "graceful-fs@4.1.11",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "from": "has-unicode@2.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "from": "hawk@3.1.3",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "from": "fstream@1.0.11",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "from": "http-signature@1.1.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "from": "inflight@1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "from": "hoek@2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "from": "is-fullwidth-code-point@1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
-            },
-            "ini": {
-              "version": "1.3.4",
-              "from": "ini@1.3.4",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "from": "is-typedarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "from": "jsbn@0.1.1",
-              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "from": "json-schema@0.2.3",
-              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "from": "jsonify@0.0.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-db": {
-              "version": "1.27.0",
-              "from": "mime-db@1.27.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "from": "json-stable-stringify@1.0.1",
-              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "from": "minimatch@3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.15",
-              "from": "mime-types@2.1.15",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
-            },
-            "ms": {
-              "version": "2.0.0",
-              "from": "ms@2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "from": "number-is-nan@1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-            },
-            "npmlog": {
-              "version": "4.1.0",
-              "from": "npmlog@4.1.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz"
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "from": "oauth-sign@0.8.2",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-            },
-            "once": {
-              "version": "1.4.0",
-              "from": "once@1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "from": "os-homedir@1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "from": "path-is-absolute@1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "from": "os-tmpdir@1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "from": "osenv@0.1.4",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "from": "performance-now@0.2.0",
-              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
-            },
-            "readable-stream": {
-              "version": "2.3.1",
-              "from": "readable-stream@2.3.1",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz"
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "from": "process-nextick-args@1.0.7",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-            },
-            "qs": {
-              "version": "6.4.0",
-              "from": "qs@6.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "from": "punycode@1.4.1",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "from": "set-blocking@2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "from": "safe-buffer@5.1.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-            },
-            "request": {
-              "version": "2.81.0",
-              "from": "request@2.81.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "from": "sntp@1.0.9",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "from": "string-width@1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "from": "signal-exit@3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "from": "strip-json-comments@2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-            },
-            "tar-pack": {
-              "version": "3.4.0",
-              "from": "tar-pack@3.4.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "from": "tunnel-agent@0.6.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "from": "tough-cookie@2.3.2",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "from": "tweetnacl@0.14.5",
-              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-            },
-            "tar": {
-              "version": "2.2.1",
-              "from": "tar@2.2.1",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "from": "util-deprecate@1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "from": "uid-number@0.0.6",
-              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "from": "wrappy@1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-            },
-            "verror": {
-              "version": "1.3.6",
-              "from": "verror@1.3.6",
-              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "from": "wide-align@1.1.2",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "from": "nopt@4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz"
-            },
-            "semver": {
-              "version": "5.3.0",
-              "from": "semver@5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "from": "rimraf@2.6.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "from": "uuid@3.1.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "from": "dashdash@1.14.1",
-              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "from": "assert-plus@1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                }
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "from": "getpass@0.1.7",
-              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "from": "assert-plus@1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                }
-              }
-            },
-            "jsprim": {
-              "version": "1.4.0",
-              "from": "jsprim@1.4.0",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "from": "assert-plus@1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                }
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.2",
-              "from": "string_decoder@1.0.2",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-              "dependencies": {
-                "safe-buffer": {
-                  "version": "5.0.1",
-                  "from": "safe-buffer@5.0.1",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-                }
-              }
-            },
-            "rc": {
-              "version": "1.2.1",
-              "from": "rc@1.2.1",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                }
-              }
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "from": "sshpk@1.13.1",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "from": "assert-plus@1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
+      "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.4.3.tgz"
     },
     "grunt-contrib-copy": {
       "version": "1.0.0",
-      "from": "grunt-contrib-copy@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "file-sync-cmp": {
-          "version": "0.1.1",
-          "from": "file-sync-cmp@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz"
-        }
-      }
+      "from": "grunt-contrib-copy@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz"
     },
     "grunt-contrib-jshint": {
       "version": "1.1.0",
-      "from": "grunt-contrib-jshint@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        },
-        "jshint": {
-          "version": "2.9.5",
-          "from": "jshint@>=2.9.4 <2.10.0",
-          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
-          "dependencies": {
-            "cli": {
-              "version": "1.0.1",
-              "from": "cli@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "7.1.2",
-                  "from": "glob@>=7.1.1 <8.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                  "dependencies": {
-                    "fs.realpath": {
-                      "version": "1.0.0",
-                      "from": "fs.realpath@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-                    },
-                    "inflight": {
-                      "version": "1.0.6",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    },
-                    "once": {
-                      "version": "1.4.0",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.1",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "console-browserify": {
-              "version": "1.1.0",
-              "from": "console-browserify@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-              "dependencies": {
-                "date-now": {
-                  "version": "0.1.4",
-                  "from": "date-now@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
-                }
-              }
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "exit@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-            },
-            "htmlparser2": {
-              "version": "3.8.3",
-              "from": "htmlparser2@>=3.8.0 <3.9.0",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-              "dependencies": {
-                "domhandler": {
-                  "version": "2.3.0",
-                  "from": "domhandler@>=2.3.0 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
-                },
-                "domutils": {
-                  "version": "1.5.1",
-                  "from": "domutils@>=1.5.0 <1.6.0",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                  "dependencies": {
-                    "dom-serializer": {
-                      "version": "0.1.0",
-                      "from": "dom-serializer@>=0.0.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                      "dependencies": {
-                        "domelementtype": {
-                          "version": "1.1.3",
-                          "from": "domelementtype@>=1.1.1 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                        },
-                        "entities": {
-                          "version": "1.1.1",
-                          "from": "entities@>=1.1.1 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "domelementtype": {
-                  "version": "1.3.0",
-                  "from": "domelementtype@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-                },
-                "readable-stream": {
-                  "version": "1.1.14",
-                  "from": "readable-stream@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    }
-                  }
-                },
-                "entities": {
-                  "version": "1.0.0",
-                  "from": "entities@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "from": "minimatch@>=3.0.2 <3.1.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "from": "brace-expansion@>=1.1.7 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "from": "balanced-match@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "shelljs": {
-              "version": "0.3.0",
-              "from": "shelljs@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-            },
-            "strip-json-comments": {
-              "version": "1.0.4",
-              "from": "strip-json-comments@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-            },
-            "lodash": {
-              "version": "3.7.0",
-              "from": "lodash@>=3.7.0 <3.8.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
-            }
-          }
-        }
-      }
+      "from": "grunt-contrib-jshint@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz"
     },
     "grunt-contrib-nodeunit": {
       "version": "1.0.0",
-      "from": "grunt-contrib-nodeunit@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-nodeunit/-/grunt-contrib-nodeunit-1.0.0.tgz",
-      "dependencies": {
-        "nodeunit": {
-          "version": "0.9.5",
-          "from": "nodeunit@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.9.5.tgz",
-          "dependencies": {
-            "tap": {
-              "version": "7.1.2",
-              "from": "tap@>=7.0.0 <8.0.0",
-              "resolved": "https://registry.npmjs.org/tap/-/tap-7.1.2.tgz",
-              "dependencies": {
-                "bluebird": {
-                  "version": "3.5.0",
-                  "from": "bluebird@>=3.3.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
-                },
-                "clean-yaml-object": {
-                  "version": "0.1.0",
-                  "from": "clean-yaml-object@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz"
-                },
-                "color-support": {
-                  "version": "1.1.3",
-                  "from": "color-support@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz"
-                },
-                "coveralls": {
-                  "version": "2.13.1",
-                  "from": "coveralls@>=2.11.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
-                  "dependencies": {
-                    "js-yaml": {
-                      "version": "3.6.1",
-                      "from": "js-yaml@3.6.1",
-                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-                      "dependencies": {
-                        "argparse": {
-                          "version": "1.0.9",
-                          "from": "argparse@>=1.0.7 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                          "dependencies": {
-                            "sprintf-js": {
-                              "version": "1.0.3",
-                              "from": "sprintf-js@>=1.0.2 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "esprima": {
-                          "version": "2.7.3",
-                          "from": "esprima@>=2.6.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
-                        }
-                      }
-                    },
-                    "lcov-parse": {
-                      "version": "0.0.10",
-                      "from": "lcov-parse@0.0.10",
-                      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz"
-                    },
-                    "log-driver": {
-                      "version": "1.2.5",
-                      "from": "log-driver@1.2.5",
-                      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz"
-                    },
-                    "minimist": {
-                      "version": "1.2.0",
-                      "from": "minimist@1.2.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                    },
-                    "request": {
-                      "version": "2.79.0",
-                      "from": "request@2.79.0",
-                      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-                      "dependencies": {
-                        "aws-sign2": {
-                          "version": "0.6.0",
-                          "from": "aws-sign2@>=0.6.0 <0.7.0",
-                          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-                        },
-                        "aws4": {
-                          "version": "1.6.0",
-                          "from": "aws4@>=1.2.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
-                        },
-                        "caseless": {
-                          "version": "0.11.0",
-                          "from": "caseless@>=0.11.0 <0.12.0",
-                          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                        },
-                        "combined-stream": {
-                          "version": "1.0.5",
-                          "from": "combined-stream@>=1.0.5 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                          "dependencies": {
-                            "delayed-stream": {
-                              "version": "1.0.0",
-                              "from": "delayed-stream@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "extend": {
-                          "version": "3.0.1",
-                          "from": "extend@>=3.0.0 <3.1.0",
-                          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
-                        },
-                        "forever-agent": {
-                          "version": "0.6.1",
-                          "from": "forever-agent@>=0.6.1 <0.7.0",
-                          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                        },
-                        "form-data": {
-                          "version": "2.1.4",
-                          "from": "form-data@>=2.1.1 <2.2.0",
-                          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                          "dependencies": {
-                            "asynckit": {
-                              "version": "0.4.0",
-                              "from": "asynckit@>=0.4.0 <0.5.0",
-                              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-                            }
-                          }
-                        },
-                        "har-validator": {
-                          "version": "2.0.6",
-                          "from": "har-validator@>=2.0.6 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.3",
-                              "from": "chalk@>=1.1.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.1",
-                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.1.1",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.1.1",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "commander": {
-                              "version": "2.11.0",
-                              "from": "commander@>=2.9.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
-                            },
-                            "is-my-json-valid": {
-                              "version": "2.16.0",
-                              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-                              "dependencies": {
-                                "generate-function": {
-                                  "version": "2.0.0",
-                                  "from": "generate-function@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                                },
-                                "generate-object-property": {
-                                  "version": "1.2.0",
-                                  "from": "generate-object-property@>=1.1.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                                  "dependencies": {
-                                    "is-property": {
-                                      "version": "1.0.2",
-                                      "from": "is-property@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                                    }
-                                  }
-                                },
-                                "jsonpointer": {
-                                  "version": "4.0.1",
-                                  "from": "jsonpointer@>=4.0.0 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
-                                },
-                                "xtend": {
-                                  "version": "4.0.1",
-                                  "from": "xtend@>=4.0.0 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                                }
-                              }
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.1",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "hawk": {
-                          "version": "3.1.3",
-                          "from": "hawk@>=3.1.3 <3.2.0",
-                          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                          "dependencies": {
-                            "hoek": {
-                              "version": "2.16.3",
-                              "from": "hoek@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                            },
-                            "boom": {
-                              "version": "2.10.1",
-                              "from": "boom@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                            },
-                            "cryptiles": {
-                              "version": "2.0.5",
-                              "from": "cryptiles@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                            },
-                            "sntp": {
-                              "version": "1.0.9",
-                              "from": "sntp@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                            }
-                          }
-                        },
-                        "http-signature": {
-                          "version": "1.1.1",
-                          "from": "http-signature@>=1.1.0 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                          "dependencies": {
-                            "assert-plus": {
-                              "version": "0.2.0",
-                              "from": "assert-plus@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                            },
-                            "jsprim": {
-                              "version": "1.4.0",
-                              "from": "jsprim@>=1.2.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                              "dependencies": {
-                                "assert-plus": {
-                                  "version": "1.0.0",
-                                  "from": "assert-plus@1.0.0",
-                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                                },
-                                "extsprintf": {
-                                  "version": "1.0.2",
-                                  "from": "extsprintf@1.0.2",
-                                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                                },
-                                "json-schema": {
-                                  "version": "0.2.3",
-                                  "from": "json-schema@0.2.3",
-                                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-                                },
-                                "verror": {
-                                  "version": "1.3.6",
-                                  "from": "verror@1.3.6",
-                                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                                }
-                              }
-                            },
-                            "sshpk": {
-                              "version": "1.13.1",
-                              "from": "sshpk@>=1.7.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-                              "dependencies": {
-                                "asn1": {
-                                  "version": "0.2.3",
-                                  "from": "asn1@>=0.2.3 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                                },
-                                "assert-plus": {
-                                  "version": "1.0.0",
-                                  "from": "assert-plus@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                                },
-                                "dashdash": {
-                                  "version": "1.14.1",
-                                  "from": "dashdash@>=1.12.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
-                                },
-                                "getpass": {
-                                  "version": "0.1.7",
-                                  "from": "getpass@>=0.1.1 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
-                                },
-                                "jsbn": {
-                                  "version": "0.1.1",
-                                  "from": "jsbn@>=0.1.0 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-                                },
-                                "tweetnacl": {
-                                  "version": "0.14.5",
-                                  "from": "tweetnacl@>=0.14.0 <0.15.0",
-                                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-                                },
-                                "ecc-jsbn": {
-                                  "version": "0.1.1",
-                                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                                },
-                                "bcrypt-pbkdf": {
-                                  "version": "1.0.1",
-                                  "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "is-typedarray": {
-                          "version": "1.0.0",
-                          "from": "is-typedarray@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-                        },
-                        "isstream": {
-                          "version": "0.1.2",
-                          "from": "isstream@>=0.1.2 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                        },
-                        "json-stringify-safe": {
-                          "version": "5.0.1",
-                          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-                          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                        },
-                        "mime-types": {
-                          "version": "2.1.15",
-                          "from": "mime-types@>=2.1.7 <2.2.0",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-                          "dependencies": {
-                            "mime-db": {
-                              "version": "1.27.0",
-                              "from": "mime-db@>=1.27.0 <1.28.0",
-                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
-                            }
-                          }
-                        },
-                        "oauth-sign": {
-                          "version": "0.8.2",
-                          "from": "oauth-sign@>=0.8.1 <0.9.0",
-                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-                        },
-                        "qs": {
-                          "version": "6.3.2",
-                          "from": "qs@>=6.3.0 <6.4.0",
-                          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz"
-                        },
-                        "stringstream": {
-                          "version": "0.0.5",
-                          "from": "stringstream@>=0.0.4 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-                        },
-                        "tough-cookie": {
-                          "version": "2.3.2",
-                          "from": "tough-cookie@>=2.3.0 <2.4.0",
-                          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                          "dependencies": {
-                            "punycode": {
-                              "version": "1.4.1",
-                              "from": "punycode@>=1.4.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-                            }
-                          }
-                        },
-                        "tunnel-agent": {
-                          "version": "0.4.3",
-                          "from": "tunnel-agent@>=0.4.1 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
-                        },
-                        "uuid": {
-                          "version": "3.1.0",
-                          "from": "uuid@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "deeper": {
-                  "version": "2.1.0",
-                  "from": "deeper@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz"
-                },
-                "foreground-child": {
-                  "version": "1.5.6",
-                  "from": "foreground-child@>=1.3.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-                  "dependencies": {
-                    "cross-spawn": {
-                      "version": "4.0.2",
-                      "from": "cross-spawn@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "4.1.1",
-                          "from": "lru-cache@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-                          "dependencies": {
-                            "pseudomap": {
-                              "version": "1.0.2",
-                              "from": "pseudomap@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
-                            },
-                            "yallist": {
-                              "version": "2.1.2",
-                              "from": "yallist@>=2.1.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
-                            }
-                          }
-                        },
-                        "which": {
-                          "version": "1.2.14",
-                          "from": "which@>=1.2.9 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-                          "dependencies": {
-                            "isexe": {
-                              "version": "2.0.0",
-                              "from": "isexe@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "glob": {
-                  "version": "7.1.2",
-                  "from": "glob@>=7.0.0 <8.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                  "dependencies": {
-                    "fs.realpath": {
-                      "version": "1.0.0",
-                      "from": "fs.realpath@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-                    },
-                    "inflight": {
-                      "version": "1.0.6",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    },
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "from": "minimatch@>=3.0.4 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "from": "brace-expansion@>=1.1.7 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "from": "balanced-match@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.4.0",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.1",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                    }
-                  }
-                },
-                "isexe": {
-                  "version": "1.1.2",
-                  "from": "isexe@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
-                },
-                "js-yaml": {
-                  "version": "3.9.0",
-                  "from": "js-yaml@>=3.3.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
-                  "dependencies": {
-                    "argparse": {
-                      "version": "1.0.9",
-                      "from": "argparse@>=1.0.7 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                      "dependencies": {
-                        "sprintf-js": {
-                          "version": "1.0.3",
-                          "from": "sprintf-js@>=1.0.2 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                        }
-                      }
-                    },
-                    "esprima": {
-                      "version": "4.0.0",
-                      "from": "esprima@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
-                    }
-                  }
-                },
-                "nyc": {
-                  "version": "7.1.0",
-                  "from": "nyc@>=7.1.0 <8.0.0",
-                  "resolved": "https://registry.npmjs.org/nyc/-/nyc-7.1.0.tgz",
-                  "dependencies": {
-                    "arrify": {
-                      "version": "1.0.1",
-                      "from": "arrify@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-                    },
-                    "caching-transform": {
-                      "version": "1.0.1",
-                      "from": "caching-transform@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz"
-                    },
-                    "convert-source-map": {
-                      "version": "1.3.0",
-                      "from": "convert-source-map@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz"
-                    },
-                    "default-require-extensions": {
-                      "version": "1.0.0",
-                      "from": "default-require-extensions@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz"
-                    },
-                    "find-cache-dir": {
-                      "version": "0.1.1",
-                      "from": "find-cache-dir@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz"
-                    },
-                    "find-up": {
-                      "version": "1.1.2",
-                      "from": "find-up@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
-                    },
-                    "foreground-child": {
-                      "version": "1.5.3",
-                      "from": "foreground-child@>=1.5.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.3.tgz"
-                    },
-                    "glob": {
-                      "version": "7.0.5",
-                      "from": "glob@>=7.0.3 <8.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
-                    },
-                    "istanbul-lib-coverage": {
-                      "version": "1.0.0-alpha.4",
-                      "from": "istanbul-lib-coverage@>=1.0.0-alpha.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0-alpha.4.tgz"
-                    },
-                    "istanbul-lib-hook": {
-                      "version": "1.0.0-alpha.4",
-                      "from": "istanbul-lib-hook@>=1.0.0-alpha.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0-alpha.4.tgz"
-                    },
-                    "istanbul-lib-instrument": {
-                      "version": "1.1.0-alpha.4",
-                      "from": "istanbul-lib-instrument@>=1.1.0-alpha.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.1.0-alpha.4.tgz"
-                    },
-                    "istanbul-lib-report": {
-                      "version": "1.0.0-alpha.3",
-                      "from": "istanbul-lib-report@>=1.0.0-alpha.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.0.0-alpha.3.tgz",
-                      "dependencies": {
-                        "supports-color": {
-                          "version": "3.1.2",
-                          "from": "supports-color@>=3.1.2 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
-                        }
-                      }
-                    },
-                    "istanbul-lib-source-maps": {
-                      "version": "1.0.0-alpha.10",
-                      "from": "istanbul-lib-source-maps@>=1.0.0-alpha.10 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.0.0-alpha.10.tgz"
-                    },
-                    "istanbul-reports": {
-                      "version": "1.0.0-alpha.8",
-                      "from": "istanbul-reports@>=1.0.0-alpha.8 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.0-alpha.8.tgz"
-                    },
-                    "md5-hex": {
-                      "version": "1.3.0",
-                      "from": "md5-hex@>=1.2.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz"
-                    },
-                    "micromatch": {
-                      "version": "2.3.11",
-                      "from": "micromatch@>=2.3.11 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-                    },
-                    "pkg-up": {
-                      "version": "1.0.0",
-                      "from": "pkg-up@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz"
-                    },
-                    "resolve-from": {
-                      "version": "2.0.0",
-                      "from": "resolve-from@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
-                    },
-                    "rimraf": {
-                      "version": "2.5.4",
-                      "from": "rimraf@>=2.5.4 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-                    },
-                    "signal-exit": {
-                      "version": "3.0.0",
-                      "from": "signal-exit@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
-                    },
-                    "spawn-wrap": {
-                      "version": "1.2.4",
-                      "from": "spawn-wrap@>=1.2.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.2.4.tgz",
-                      "dependencies": {
-                        "signal-exit": {
-                          "version": "2.1.2",
-                          "from": "signal-exit@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
-                        }
-                      }
-                    },
-                    "test-exclude": {
-                      "version": "1.1.0",
-                      "from": "test-exclude@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-1.1.0.tgz"
-                    },
-                    "yargs": {
-                      "version": "4.8.1",
-                      "from": "yargs@>=4.8.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-                      "dependencies": {
-                        "cliui": {
-                          "version": "3.2.0",
-                          "from": "cliui@>=3.2.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
-                        },
-                        "window-size": {
-                          "version": "0.2.0",
-                          "from": "window-size@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
-                        }
-                      }
-                    },
-                    "yargs-parser": {
-                      "version": "2.4.1",
-                      "from": "yargs-parser@>=2.4.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "3.0.0",
-                          "from": "camelcase@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-                        }
-                      }
-                    },
-                    "align-text": {
-                      "version": "0.1.4",
-                      "from": "align-text@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
-                    },
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                    },
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    },
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "from": "ansi-styles@>=2.2.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                    },
-                    "append-transform": {
-                      "version": "0.3.0",
-                      "from": "append-transform@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.3.0.tgz"
-                    },
-                    "arr-flatten": {
-                      "version": "1.0.1",
-                      "from": "arr-flatten@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
-                    },
-                    "array-unique": {
-                      "version": "0.2.1",
-                      "from": "array-unique@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-                    },
-                    "async": {
-                      "version": "1.5.2",
-                      "from": "async@>=1.4.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-                    },
-                    "babel-code-frame": {
-                      "version": "6.11.0",
-                      "from": "babel-code-frame@>=6.8.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz"
-                    },
-                    "arr-diff": {
-                      "version": "2.0.0",
-                      "from": "arr-diff@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
-                    },
-                    "babel-messages": {
-                      "version": "6.8.0",
-                      "from": "babel-messages@>=6.8.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                    },
-                    "babel-runtime": {
-                      "version": "6.9.2",
-                      "from": "babel-runtime@>=6.9.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz"
-                    },
-                    "babel-template": {
-                      "version": "6.9.0",
-                      "from": "babel-template@>=6.9.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.9.0.tgz"
-                    },
-                    "babel-traverse": {
-                      "version": "6.11.4",
-                      "from": "babel-traverse@>=6.9.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.11.4.tgz"
-                    },
-                    "babel-types": {
-                      "version": "6.11.1",
-                      "from": "babel-types@>=6.10.2 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.11.1.tgz"
-                    },
-                    "babel-generator": {
-                      "version": "6.11.4",
-                      "from": "babel-generator@>=6.11.3 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.11.4.tgz"
-                    },
-                    "babylon": {
-                      "version": "6.8.4",
-                      "from": "babylon@>=6.8.1 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz"
-                    },
-                    "balanced-match": {
-                      "version": "0.4.2",
-                      "from": "balanced-match@>=0.4.1 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                    },
-                    "brace-expansion": {
-                      "version": "1.1.6",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-                    },
-                    "braces": {
-                      "version": "1.8.5",
-                      "from": "braces@>=1.8.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
-                    },
-                    "builtin-modules": {
-                      "version": "1.1.1",
-                      "from": "builtin-modules@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-                    },
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                    },
-                    "chalk": {
-                      "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-                    },
-                    "center-align": {
-                      "version": "0.1.3",
-                      "from": "center-align@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
-                    },
-                    "code-point-at": {
-                      "version": "1.0.0",
-                      "from": "code-point-at@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
-                    },
-                    "core-js": {
-                      "version": "2.4.1",
-                      "from": "core-js@>=2.4.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                    },
-                    "commondir": {
-                      "version": "1.0.1",
-                      "from": "commondir@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    },
-                    "cross-spawn": {
-                      "version": "4.0.0",
-                      "from": "cross-spawn@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-                    },
-                    "decamelize": {
-                      "version": "1.2.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                    },
-                    "error-ex": {
-                      "version": "1.3.0",
-                      "from": "error-ex@>=1.2.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "expand-brackets": {
-                      "version": "0.1.5",
-                      "from": "expand-brackets@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
-                    },
-                    "expand-range": {
-                      "version": "1.8.2",
-                      "from": "expand-range@>=1.8.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
-                    },
-                    "filename-regex": {
-                      "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
-                    },
-                    "extglob": {
-                      "version": "0.3.2",
-                      "from": "extglob@>=0.3.1 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
-                    },
-                    "for-own": {
-                      "version": "0.1.4",
-                      "from": "for-own@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
-                    },
-                    "fill-range": {
-                      "version": "2.2.3",
-                      "from": "fill-range@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
-                    },
-                    "for-in": {
-                      "version": "0.1.5",
-                      "from": "for-in@>=0.1.5 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
-                    },
-                    "fs.realpath": {
-                      "version": "1.0.0",
-                      "from": "fs.realpath@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-                    },
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "get-stdin@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                    },
-                    "glob-parent": {
-                      "version": "2.0.0",
-                      "from": "glob-parent@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
-                    },
-                    "glob-base": {
-                      "version": "0.3.0",
-                      "from": "glob-base@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
-                    },
-                    "globals": {
-                      "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.4",
-                      "from": "graceful-fs@>=4.1.2 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-                    },
-                    "get-caller-file": {
-                      "version": "1.0.1",
-                      "from": "get-caller-file@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.1.tgz"
-                    },
-                    "hosted-git-info": {
-                      "version": "2.1.5",
-                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
-                    },
-                    "has-flag": {
-                      "version": "1.0.0",
-                      "from": "has-flag@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                    },
-                    "imurmurhash": {
-                      "version": "0.1.4",
-                      "from": "imurmurhash@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.1",
-                      "from": "invariant@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
-                    },
-                    "inflight": {
-                      "version": "1.0.5",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
-                    },
-                    "is-builtin-module": {
-                      "version": "1.0.0",
-                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
-                    },
-                    "invert-kv": {
-                      "version": "1.0.0",
-                      "from": "invert-kv@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-                    },
-                    "is-dotfile": {
-                      "version": "1.0.2",
-                      "from": "is-dotfile@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
-                    },
-                    "is-arrayish": {
-                      "version": "0.2.1",
-                      "from": "is-arrayish@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                    },
-                    "is-equal-shallow": {
-                      "version": "0.1.3",
-                      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
-                    },
-                    "is-extendable": {
-                      "version": "0.1.1",
-                      "from": "is-extendable@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-                    },
-                    "is-buffer": {
-                      "version": "1.1.3",
-                      "from": "is-buffer@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
-                    },
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    },
-                    "is-finite": {
-                      "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
-                    },
-                    "is-glob": {
-                      "version": "2.0.1",
-                      "from": "is-glob@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-                    },
-                    "is-number": {
-                      "version": "2.1.0",
-                      "from": "is-number@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
-                    },
-                    "is-primitive": {
-                      "version": "2.0.0",
-                      "from": "is-primitive@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-                    },
-                    "is-utf8": {
-                      "version": "0.2.1",
-                      "from": "is-utf8@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                    },
-                    "is-posix-bracket": {
-                      "version": "0.1.1",
-                      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
-                    },
-                    "isexe": {
-                      "version": "1.1.2",
-                      "from": "isexe@>=1.1.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
-                    },
-                    "isobject": {
-                      "version": "2.1.0",
-                      "from": "isobject@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "2.0.0",
-                      "from": "js-tokens@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                    },
-                    "kind-of": {
-                      "version": "3.0.3",
-                      "from": "kind-of@>=3.0.2 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz"
-                    },
-                    "lcid": {
-                      "version": "1.0.0",
-                      "from": "lcid@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
-                    },
-                    "lazy-cache": {
-                      "version": "1.0.4",
-                      "from": "lazy-cache@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-                    },
-                    "lodash": {
-                      "version": "4.13.1",
-                      "from": "lodash@>=4.2.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
-                    },
-                    "load-json-file": {
-                      "version": "1.1.0",
-                      "from": "load-json-file@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
-                    },
-                    "lodash.assign": {
-                      "version": "4.0.9",
-                      "from": "lodash.assign@>=4.0.9 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz"
-                    },
-                    "lodash.keys": {
-                      "version": "4.0.7",
-                      "from": "lodash.keys@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz"
-                    },
-                    "lodash.rest": {
-                      "version": "4.0.3",
-                      "from": "lodash.rest@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz"
-                    },
-                    "longest": {
-                      "version": "1.0.1",
-                      "from": "longest@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                    },
-                    "lru-cache": {
-                      "version": "4.0.1",
-                      "from": "lru-cache@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
-                    },
-                    "md5-o-matic": {
-                      "version": "0.1.1",
-                      "from": "md5-o-matic@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "3.0.2",
-                      "from": "minimatch@>=3.0.2 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
-                    },
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    },
-                    "ms": {
-                      "version": "0.7.1",
-                      "from": "ms@0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    },
-                    "normalize-path": {
-                      "version": "2.0.1",
-                      "from": "normalize-path@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
-                    },
-                    "normalize-package-data": {
-                      "version": "2.3.5",
-                      "from": "normalize-package-data@>=2.3.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
-                    },
-                    "object.omit": {
-                      "version": "2.0.0",
-                      "from": "object.omit@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
-                    },
-                    "optimist": {
-                      "version": "0.6.1",
-                      "from": "optimist@>=0.6.1 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
-                    },
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    },
-                    "os-locale": {
-                      "version": "1.4.0",
-                      "from": "os-locale@>=1.4.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
-                    },
-                    "parse-glob": {
-                      "version": "3.0.4",
-                      "from": "parse-glob@>=3.0.4 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
-                    },
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                    },
-                    "parse-json": {
-                      "version": "2.2.0",
-                      "from": "parse-json@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
-                    },
-                    "path-parse": {
-                      "version": "1.0.5",
-                      "from": "path-parse@>=1.0.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
-                    },
-                    "pify": {
-                      "version": "2.3.0",
-                      "from": "pify@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                    },
-                    "path-type": {
-                      "version": "1.1.0",
-                      "from": "path-type@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
-                    },
-                    "pinkie": {
-                      "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-                    },
-                    "path-exists": {
-                      "version": "2.1.0",
-                      "from": "path-exists@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                    },
-                    "pkg-dir": {
-                      "version": "1.0.0",
-                      "from": "pkg-dir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
-                    },
-                    "preserve": {
-                      "version": "0.2.0",
-                      "from": "preserve@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
-                    },
-                    "pseudomap": {
-                      "version": "1.0.2",
-                      "from": "pseudomap@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
-                    },
-                    "randomatic": {
-                      "version": "1.1.5",
-                      "from": "randomatic@>=1.1.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
-                    },
-                    "read-pkg": {
-                      "version": "1.1.0",
-                      "from": "read-pkg@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-                    },
-                    "regenerator-runtime": {
-                      "version": "0.9.5",
-                      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
-                    },
-                    "read-pkg-up": {
-                      "version": "1.0.1",
-                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
-                    },
-                    "regex-cache": {
-                      "version": "0.4.3",
-                      "from": "regex-cache@>=0.4.2 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
-                    },
-                    "repeat-element": {
-                      "version": "1.1.2",
-                      "from": "repeat-element@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-                    },
-                    "repeat-string": {
-                      "version": "1.5.4",
-                      "from": "repeat-string@>=1.5.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
-                    },
-                    "repeating": {
-                      "version": "1.1.3",
-                      "from": "repeating@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
-                    },
-                    "require-directory": {
-                      "version": "2.1.1",
-                      "from": "require-directory@>=2.1.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
-                    },
-                    "right-align": {
-                      "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
-                    },
-                    "require-main-filename": {
-                      "version": "1.0.1",
-                      "from": "require-main-filename@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
-                    },
-                    "semver": {
-                      "version": "5.3.0",
-                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-                    },
-                    "set-blocking": {
-                      "version": "2.0.0",
-                      "from": "set-blocking@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-                    },
-                    "source-map": {
-                      "version": "0.5.6",
-                      "from": "source-map@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-                    },
-                    "slide": {
-                      "version": "1.1.6",
-                      "from": "slide@>=1.1.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-                    },
-                    "spdx-correct": {
-                      "version": "1.0.2",
-                      "from": "spdx-correct@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
-                    },
-                    "spdx-exceptions": {
-                      "version": "1.0.5",
-                      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.5.tgz"
-                    },
-                    "spdx-expression-parse": {
-                      "version": "1.0.2",
-                      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
-                    },
-                    "string-width": {
-                      "version": "1.0.1",
-                      "from": "string-width@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-                    },
-                    "strip-bom": {
-                      "version": "2.0.0",
-                      "from": "strip-bom@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                    },
-                    "spdx-license-ids": {
-                      "version": "1.2.1",
-                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.2",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                    },
-                    "uglify-to-browserify": {
-                      "version": "1.0.2",
-                      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-                    },
-                    "validate-npm-package-license": {
-                      "version": "3.0.1",
-                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-                    },
-                    "which": {
-                      "version": "1.2.10",
-                      "from": "which@>=1.2.9 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
-                    },
-                    "which-module": {
-                      "version": "1.0.0",
-                      "from": "which-module@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
-                    },
-                    "window-size": {
-                      "version": "0.1.0",
-                      "from": "window-size@0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                    },
-                    "wordwrap": {
-                      "version": "0.0.3",
-                      "from": "wordwrap@>=0.0.2 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                    },
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    },
-                    "wrap-ansi": {
-                      "version": "2.0.0",
-                      "from": "wrap-ansi@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
-                    },
-                    "y18n": {
-                      "version": "3.2.1",
-                      "from": "y18n@>=3.2.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
-                    },
-                    "write-file-atomic": {
-                      "version": "1.1.4",
-                      "from": "write-file-atomic@>=1.1.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz"
-                    },
-                    "yallist": {
-                      "version": "2.0.0",
-                      "from": "yallist@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
-                    },
-                    "cliui": {
-                      "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                      "dependencies": {
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                        }
-                      }
-                    },
-                    "detect-indent": {
-                      "version": "3.0.1",
-                      "from": "detect-indent@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        }
-                      }
-                    },
-                    "handlebars": {
-                      "version": "4.0.5",
-                      "from": "handlebars@>=4.0.3 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
-                      "dependencies": {
-                        "source-map": {
-                          "version": "0.4.4",
-                          "from": "source-map@>=0.4.4 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
-                        }
-                      }
-                    },
-                    "loose-envify": {
-                      "version": "1.2.0",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "1.0.3",
-                          "from": "js-tokens@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
-                        }
-                      }
-                    },
-                    "uglify-js": {
-                      "version": "2.7.0",
-                      "from": "uglify-js@>=2.6.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.0.tgz",
-                      "dependencies": {
-                        "async": {
-                          "version": "0.2.10",
-                          "from": "async@>=0.2.6 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                        },
-                        "yargs": {
-                          "version": "3.10.0",
-                          "from": "yargs@>=3.10.0 <3.11.0",
-                          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "only-shallow": {
-                  "version": "1.2.0",
-                  "from": "only-shallow@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/only-shallow/-/only-shallow-1.2.0.tgz"
-                },
-                "opener": {
-                  "version": "1.4.3",
-                  "from": "opener@>=1.4.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz"
-                },
-                "os-homedir": {
-                  "version": "1.0.1",
-                  "from": "os-homedir@1.0.1",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                },
-                "readable-stream": {
-                  "version": "2.3.3",
-                  "from": "readable-stream@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.3 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "safe-buffer": {
-                      "version": "5.1.1",
-                      "from": "safe-buffer@>=5.1.1 <5.2.0",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.3 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "from": "signal-exit@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-                },
-                "stack-utils": {
-                  "version": "0.4.0",
-                  "from": "stack-utils@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-0.4.0.tgz"
-                },
-                "tap-mocha-reporter": {
-                  "version": "2.0.1",
-                  "from": "tap-mocha-reporter@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-2.0.1.tgz",
-                  "dependencies": {
-                    "debug": {
-                      "version": "2.6.8",
-                      "from": "debug@>=2.1.3 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "from": "ms@2.0.0",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "diff": {
-                      "version": "1.4.0",
-                      "from": "diff@>=1.3.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    },
-                    "unicode-length": {
-                      "version": "1.0.3",
-                      "from": "unicode-length@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
-                      "dependencies": {
-                        "punycode": {
-                          "version": "1.4.1",
-                          "from": "punycode@>=1.3.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "tap-parser": {
-                  "version": "2.2.3",
-                  "from": "tap-parser@>=2.2.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-2.2.3.tgz",
-                  "dependencies": {
-                    "events-to-array": {
-                      "version": "1.1.2",
-                      "from": "events-to-array@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz"
-                    }
-                  }
-                },
-                "tmatch": {
-                  "version": "2.0.1",
-                  "from": "tmatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
+      "from": "grunt-contrib-nodeunit@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-nodeunit/-/grunt-contrib-nodeunit-1.0.0.tgz"
     },
     "grunt-env": {
       "version": "0.4.4",
       "from": "grunt-env@>=0.4.4 <0.5.0",
       "resolved": "https://registry.npmjs.org/grunt-env/-/grunt-env-0.4.4.tgz",
       "dependencies": {
-        "ini": {
-          "version": "1.3.4",
-          "from": "ini@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-        },
         "lodash": {
           "version": "2.4.2",
           "from": "lodash@>=2.4.1 <2.5.0",
@@ -3276,1440 +770,2615 @@
     },
     "grunt-eslint": {
       "version": "18.1.0",
-      "from": "grunt-eslint@>=18.0.0 <19.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-18.1.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "eslint": {
-          "version": "2.13.1",
-          "from": "eslint@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.6.0",
-              "from": "concat-stream@>=1.4.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.3 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "from": "typedarray@>=0.0.6 <0.0.7",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                },
-                "readable-stream": {
-                  "version": "2.3.3",
-                  "from": "readable-stream@>=2.2.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "safe-buffer": {
-                      "version": "5.1.1",
-                      "from": "safe-buffer@>=5.1.1 <5.2.0",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.3 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.8",
-              "from": "debug@>=2.1.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "from": "ms@2.0.0",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                }
-              }
-            },
-            "doctrine": {
-              "version": "1.5.0",
-              "from": "doctrine@>=1.2.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-              "dependencies": {
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                }
-              }
-            },
-            "es6-map": {
-              "version": "0.1.5",
-              "from": "es6-map@>=0.1.3 <0.2.0",
-              "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-              "dependencies": {
-                "d": {
-                  "version": "1.0.0",
-                  "from": "d@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
-                },
-                "es5-ext": {
-                  "version": "0.10.24",
-                  "from": "es5-ext@>=0.10.14 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz"
-                },
-                "es6-iterator": {
-                  "version": "2.0.1",
-                  "from": "es6-iterator@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
-                },
-                "es6-set": {
-                  "version": "0.1.5",
-                  "from": "es6-set@>=0.1.5 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz"
-                },
-                "es6-symbol": {
-                  "version": "3.1.1",
-                  "from": "es6-symbol@>=3.1.1 <3.2.0",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-                },
-                "event-emitter": {
-                  "version": "0.3.5",
-                  "from": "event-emitter@>=0.3.5 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
-                }
-              }
-            },
-            "escope": {
-              "version": "3.6.0",
-              "from": "escope@>=3.6.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-              "dependencies": {
-                "es6-weak-map": {
-                  "version": "2.0.2",
-                  "from": "es6-weak-map@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-                  "dependencies": {
-                    "d": {
-                      "version": "1.0.0",
-                      "from": "d@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
-                    },
-                    "es5-ext": {
-                      "version": "0.10.24",
-                      "from": "es5-ext@>=0.10.14 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz"
-                    },
-                    "es6-iterator": {
-                      "version": "2.0.1",
-                      "from": "es6-iterator@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
-                    },
-                    "es6-symbol": {
-                      "version": "3.1.1",
-                      "from": "es6-symbol@>=3.1.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-                    }
-                  }
-                },
-                "esrecurse": {
-                  "version": "4.2.0",
-                  "from": "esrecurse@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-                  "dependencies": {
-                    "object-assign": {
-                      "version": "4.1.1",
-                      "from": "object-assign@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "espree": {
-              "version": "3.4.3",
-              "from": "espree@>=3.1.6 <4.0.0",
-              "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-              "dependencies": {
-                "acorn": {
-                  "version": "5.1.1",
-                  "from": "acorn@>=5.0.1 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz"
-                },
-                "acorn-jsx": {
-                  "version": "3.0.1",
-                  "from": "acorn-jsx@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-                  "dependencies": {
-                    "acorn": {
-                      "version": "3.3.0",
-                      "from": "acorn@>=3.0.4 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "from": "estraverse@>=4.2.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "file-entry-cache": {
-              "version": "1.3.1",
-              "from": "file-entry-cache@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
-              "dependencies": {
-                "flat-cache": {
-                  "version": "1.2.2",
-                  "from": "flat-cache@>=1.2.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-                  "dependencies": {
-                    "circular-json": {
-                      "version": "0.3.1",
-                      "from": "circular-json@>=0.3.1 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz"
-                    },
-                    "del": {
-                      "version": "2.2.2",
-                      "from": "del@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-                      "dependencies": {
-                        "globby": {
-                          "version": "5.0.0",
-                          "from": "globby@>=5.0.0 <6.0.0",
-                          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-                          "dependencies": {
-                            "array-union": {
-                              "version": "1.0.2",
-                              "from": "array-union@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-                              "dependencies": {
-                                "array-uniq": {
-                                  "version": "1.0.3",
-                                  "from": "array-uniq@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
-                                }
-                              }
-                            },
-                            "arrify": {
-                              "version": "1.0.1",
-                              "from": "arrify@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "is-path-cwd": {
-                          "version": "1.0.0",
-                          "from": "is-path-cwd@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
-                        },
-                        "is-path-in-cwd": {
-                          "version": "1.0.0",
-                          "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                          "dependencies": {
-                            "is-path-inside": {
-                              "version": "1.0.0",
-                              "from": "is-path-inside@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                            }
-                          }
-                        },
-                        "rimraf": {
-                          "version": "2.6.1",
-                          "from": "rimraf@>=2.2.8 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.11",
-                      "from": "graceful-fs@>=4.1.2 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                    },
-                    "write": {
-                      "version": "0.2.1",
-                      "from": "write@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.1.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "from": "glob@>=7.0.3 <8.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "dependencies": {
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "from": "fs.realpath@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-                },
-                "inflight": {
-                  "version": "1.0.6",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "from": "minimatch@>=3.0.4 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "from": "brace-expansion@>=1.1.7 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "from": "balanced-match@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "globals": {
-              "version": "9.18.0",
-              "from": "globals@>=9.2.0 <10.0.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-            },
-            "ignore": {
-              "version": "3.3.3",
-              "from": "ignore@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz"
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "from": "imurmurhash@>=0.1.4 <0.2.0",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-            },
-            "inquirer": {
-              "version": "0.12.0",
-              "from": "inquirer@>=0.12.0 <0.13.0",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-              "dependencies": {
-                "ansi-escapes": {
-                  "version": "1.4.0",
-                  "from": "ansi-escapes@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
-                },
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                },
-                "cli-cursor": {
-                  "version": "1.0.2",
-                  "from": "cli-cursor@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-                  "dependencies": {
-                    "restore-cursor": {
-                      "version": "1.0.1",
-                      "from": "restore-cursor@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                      "dependencies": {
-                        "exit-hook": {
-                          "version": "1.1.1",
-                          "from": "exit-hook@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
-                        },
-                        "onetime": {
-                          "version": "1.1.0",
-                          "from": "onetime@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "cli-width": {
-                  "version": "2.1.0",
-                  "from": "cli-width@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
-                },
-                "figures": {
-                  "version": "1.7.0",
-                  "from": "figures@>=1.3.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                  "dependencies": {
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    },
-                    "object-assign": {
-                      "version": "4.1.1",
-                      "from": "object-assign@>=4.1.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                    }
-                  }
-                },
-                "readline2": {
-                  "version": "1.0.1",
-                  "from": "readline2@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "from": "code-point-at@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "mute-stream": {
-                      "version": "0.0.5",
-                      "from": "mute-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-                    }
-                  }
-                },
-                "run-async": {
-                  "version": "0.1.0",
-                  "from": "run-async@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.4.0",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "rx-lite": {
-                  "version": "3.1.2",
-                  "from": "rx-lite@>=3.1.2 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "from": "string-width@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "from": "code-point-at@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "from": "through@>=2.3.6 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                }
-              }
-            },
-            "is-my-json-valid": {
-              "version": "2.16.0",
-              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-              "dependencies": {
-                "generate-function": {
-                  "version": "2.0.0",
-                  "from": "generate-function@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                },
-                "generate-object-property": {
-                  "version": "1.2.0",
-                  "from": "generate-object-property@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                  "dependencies": {
-                    "is-property": {
-                      "version": "1.0.2",
-                      "from": "is-property@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                    }
-                  }
-                },
-                "jsonpointer": {
-                  "version": "4.0.1",
-                  "from": "jsonpointer@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            },
-            "is-resolvable": {
-              "version": "1.0.0",
-              "from": "is-resolvable@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-              "dependencies": {
-                "tryit": {
-                  "version": "1.0.3",
-                  "from": "tryit@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
-                }
-              }
-            },
-            "js-yaml": {
-              "version": "3.9.0",
-              "from": "js-yaml@>=3.5.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.9",
-                  "from": "argparse@>=1.0.7 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                  "dependencies": {
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "4.0.0",
-                  "from": "esprima@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
-                }
-              }
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "from": "json-stable-stringify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-              "dependencies": {
-                "jsonify": {
-                  "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-                }
-              }
-            },
-            "levn": {
-              "version": "0.3.0",
-              "from": "levn@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "from": "prelude-ls@>=1.1.2 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                },
-                "type-check": {
-                  "version": "0.3.2",
-                  "from": "type-check@>=0.3.2 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "from": "optionator@>=0.8.1 <0.9.0",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "from": "prelude-ls@>=1.1.2 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                },
-                "deep-is": {
-                  "version": "0.1.3",
-                  "from": "deep-is@>=0.1.3 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                },
-                "wordwrap": {
-                  "version": "1.0.0",
-                  "from": "wordwrap@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-                },
-                "type-check": {
-                  "version": "0.3.2",
-                  "from": "type-check@>=0.3.2 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-                },
-                "fast-levenshtein": {
-                  "version": "2.0.6",
-                  "from": "fast-levenshtein@>=2.0.4 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-            },
-            "path-is-inside": {
-              "version": "1.0.2",
-              "from": "path-is-inside@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
-            },
-            "pluralize": {
-              "version": "1.2.1",
-              "from": "pluralize@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
-            },
-            "progress": {
-              "version": "1.1.8",
-              "from": "progress@>=1.1.8 <2.0.0",
-              "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
-            },
-            "require-uncached": {
-              "version": "1.0.3",
-              "from": "require-uncached@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-              "dependencies": {
-                "caller-path": {
-                  "version": "0.1.0",
-                  "from": "caller-path@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-                  "dependencies": {
-                    "callsites": {
-                      "version": "0.2.0",
-                      "from": "callsites@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
-                    }
-                  }
-                },
-                "resolve-from": {
-                  "version": "1.0.1",
-                  "from": "resolve-from@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
-                }
-              }
-            },
-            "shelljs": {
-              "version": "0.6.1",
-              "from": "shelljs@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz"
-            },
-            "strip-json-comments": {
-              "version": "1.0.4",
-              "from": "strip-json-comments@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-            },
-            "table": {
-              "version": "3.8.3",
-              "from": "table@>=3.7.8 <4.0.0",
-              "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-              "dependencies": {
-                "ajv": {
-                  "version": "4.11.8",
-                  "from": "ajv@>=4.7.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "from": "co@>=4.6.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-                    }
-                  }
-                },
-                "ajv-keywords": {
-                  "version": "1.5.1",
-                  "from": "ajv-keywords@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz"
-                },
-                "slice-ansi": {
-                  "version": "0.0.4",
-                  "from": "slice-ansi@0.0.4",
-                  "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
-                },
-                "string-width": {
-                  "version": "2.1.0",
-                  "from": "string-width@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
-                    },
-                    "strip-ansi": {
-                      "version": "4.0.0",
-                      "from": "strip-ansi@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "3.0.0",
-                          "from": "ansi-regex@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "from": "text-table@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-            },
-            "user-home": {
-              "version": "2.0.0",
-              "from": "user-home@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
+      "from": "grunt-eslint@>=18.1.0 <18.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-18.1.0.tgz"
     },
     "grunt-shell": {
       "version": "1.3.1",
-      "from": "grunt-shell@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-1.3.1.tgz",
+      "from": "grunt-shell@>=1.3.1 <1.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-1.3.1.tgz"
+    },
+    "handlebars": {
+      "version": "4.0.10",
+      "from": "handlebars@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "npm-run-path": {
-          "version": "1.0.0",
-          "from": "npm-run-path@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-          "dependencies": {
-            "path-key": {
-              "version": "1.0.0",
-              "from": "path-key@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "from": "object-assign@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.4 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
         }
       }
     },
-    "istanbul": {
-      "version": "0.4.5",
-      "from": "istanbul@>=0.4.3 <0.5.0",
-      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+    "har-validator": {
+      "version": "2.0.6",
+      "from": "har-validator@>=2.0.6 <2.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "from": "has-flag@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "from": "hawk@>=3.1.3 <3.2.0",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "from": "hoek@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "from": "homedir-polyfill@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz"
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "from": "hooker@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "from": "htmlparser2@>=3.8.0 <3.9.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "from": "http-signature@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+    },
+    "ignore": {
+      "version": "3.3.3",
+      "from": "ignore@>=3.1.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz"
+    },
+    "iltorb": {
+      "version": "1.3.4",
+      "from": "iltorb@>=1.0.13 <2.0.0",
+      "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-1.3.4.tgz",
+      "optional": true,
       "dependencies": {
         "abbrev": {
-          "version": "1.0.9",
-          "from": "abbrev@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+          "version": "1.1.0",
+          "from": "abbrev@1.1.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "optional": true
         },
-        "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        "ajv": {
+          "version": "4.11.8",
+          "from": "ajv@4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "optional": true
         },
-        "escodegen": {
-          "version": "1.8.1",
-          "from": "escodegen@>=1.8.0 <1.9.0",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+        "ansi-regex": {
+          "version": "2.1.1",
+          "from": "ansi-regex@2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+        },
+        "aproba": {
+          "version": "1.1.2",
+          "from": "aproba@1.1.2",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "from": "are-we-there-yet@1.1.4",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "optional": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "from": "asn1@0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "from": "assert-plus@0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "from": "asynckit@0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "from": "aws-sign2@0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "from": "aws4@1.6.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "from": "balanced-match@1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "from": "bcrypt-pbkdf@1.0.1",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "optional": true
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "from": "block-stream@0.0.9",
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+        },
+        "boom": {
+          "version": "2.10.1",
+          "from": "boom@2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "from": "brace-expansion@1.1.8",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "from": "caseless@0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "from": "co@4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "from": "code-point-at@1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "from": "combined-stream@1.0.5",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "from": "concat-map@0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "from": "console-control-strings@1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "from": "core-util-is@1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "from": "cryptiles@2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "optional": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "from": "dashdash@1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "optional": true,
           "dependencies": {
-            "estraverse": {
-              "version": "1.9.3",
-              "from": "estraverse@>=1.9.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "from": "optionator@>=0.8.1 <0.9.0",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "from": "prelude-ls@>=1.1.2 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                },
-                "deep-is": {
-                  "version": "0.1.3",
-                  "from": "deep-is@>=0.1.3 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                },
-                "type-check": {
-                  "version": "0.3.2",
-                  "from": "type-check@>=0.3.2 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-                },
-                "levn": {
-                  "version": "0.3.0",
-                  "from": "levn@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
-                },
-                "fast-levenshtein": {
-                  "version": "2.0.6",
-                  "from": "fast-levenshtein@>=2.0.4 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.2.0",
-              "from": "source-map@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.1",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-                }
-              }
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
             }
           }
         },
-        "esprima": {
-          "version": "2.7.3",
-          "from": "esprima@>=2.7.0 <2.8.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+        "debug": {
+          "version": "2.6.8",
+          "from": "debug@2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "optional": true
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "from": "deep-extend@0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "from": "delayed-stream@1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "from": "delegates@1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "from": "ecc-jsbn@0.1.1",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "optional": true
+        },
+        "extend": {
+          "version": "3.0.1",
+          "from": "extend@3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "from": "extsprintf@1.0.2",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "from": "forever-agent@0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "from": "form-data@2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "optional": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "from": "fs.realpath@1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "from": "fstream@1.0.11",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "from": "fstream-ignore@1.0.5",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "from": "gauge@2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "optional": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "from": "getpass@0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
         },
         "glob": {
-          "version": "5.0.15",
-          "from": "glob@>=5.0.15 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "version": "7.1.2",
+          "from": "glob@7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "from": "graceful-fs@4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "from": "har-schema@1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "from": "har-validator@4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "from": "has-unicode@2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "from": "hawk@3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "optional": true
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "from": "hoek@2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "from": "http-signature@1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "optional": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "from": "inflight@1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "from": "inherits@2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+        },
+        "ini": {
+          "version": "1.3.4",
+          "from": "ini@1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "from": "is-fullwidth-code-point@1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "from": "is-typedarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "from": "isstream@0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "optional": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "from": "jsbn@0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "from": "json-schema@0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "from": "json-stable-stringify@1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "from": "jsonify@0.0.0",
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "from": "jsprim@1.4.0",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "optional": true,
           "dependencies": {
-            "inflight": {
-              "version": "1.0.6",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "from": "brace-expansion@>=1.1.7 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "from": "balanced-match@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
             }
           }
         },
-        "handlebars": {
-          "version": "4.0.10",
-          "from": "handlebars@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-          "dependencies": {
-            "optimist": {
-              "version": "0.6.1",
-              "from": "optimist@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                },
-                "minimist": {
-                  "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "from": "source-map@>=0.4.4 <0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.1",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-                }
-              }
-            },
-            "uglify-js": {
-              "version": "2.8.29",
-              "from": "uglify-js@>=2.6.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-              "dependencies": {
-                "source-map": {
-                  "version": "0.5.6",
-                  "from": "source-map@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-                },
-                "yargs": {
-                  "version": "3.10.0",
-                  "from": "yargs@>=3.10.0 <3.11.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                    },
-                    "cliui": {
-                      "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                      "dependencies": {
-                        "center-align": {
-                          "version": "0.1.3",
-                          "from": "center-align@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "from": "align-text@>=0.1.3 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.2.2",
-                                  "from": "kind-of@>=3.0.2 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.5",
-                                      "from": "is-buffer@>=1.1.5 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                },
-                                "repeat-string": {
-                                  "version": "1.6.1",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-                                }
-                              }
-                            },
-                            "lazy-cache": {
-                              "version": "1.0.4",
-                              "from": "lazy-cache@>=1.0.3 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-                            }
-                          }
-                        },
-                        "right-align": {
-                          "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "from": "align-text@>=0.1.3 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.2.2",
-                                  "from": "kind-of@>=3.0.2 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.5",
-                                      "from": "is-buffer@>=1.1.5 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                },
-                                "repeat-string": {
-                                  "version": "1.6.1",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.2.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                    },
-                    "window-size": {
-                      "version": "0.1.0",
-                      "from": "window-size@0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                    }
-                  }
-                },
-                "uglify-to-browserify": {
-                  "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-                }
-              }
-            }
-          }
+        "mime-db": {
+          "version": "1.27.0",
+          "from": "mime-db@1.27.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
         },
-        "js-yaml": {
-          "version": "3.9.0",
-          "from": "js-yaml@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.9",
-              "from": "argparse@>=1.0.7 <2.0.0",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-              "dependencies": {
-                "sprintf-js": {
-                  "version": "1.0.3",
-                  "from": "sprintf-js@>=1.0.2 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                }
-              }
-            },
-            "esprima": {
-              "version": "4.0.0",
-              "from": "esprima@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
-            }
-          }
+        "mime-types": {
+          "version": "2.1.15",
+          "from": "mime-types@2.1.15",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "minimatch@3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
+          "from": "mkdirp@0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        },
+        "ms": {
+          "version": "2.0.0",
+          "from": "ms@2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.36",
+          "from": "node-pre-gyp@0.6.36",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+          "optional": true
         },
         "nopt": {
-          "version": "3.0.6",
-          "from": "nopt@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+          "version": "4.0.1",
+          "from": "nopt@4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "optional": true
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "from": "npmlog@4.1.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "optional": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "from": "number-is-nan@1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "from": "oauth-sign@0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "from": "once@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "from": "once@1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "from": "os-homedir@1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "from": "os-tmpdir@1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "from": "osenv@0.1.4",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "optional": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "from": "path-is-absolute@1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "from": "performance-now@0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "from": "process-nextick-args@1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "from": "punycode@1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "from": "qs@6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "from": "rc@1.2.1",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "optional": true,
           "dependencies": {
-            "wrappy": {
-              "version": "1.0.2",
-              "from": "wrappy@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "optional": true
             }
           }
         },
-        "resolve": {
-          "version": "1.1.7",
-          "from": "resolve@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+        "readable-stream": {
+          "version": "2.3.1",
+          "from": "readable-stream@2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz"
+        },
+        "request": {
+          "version": "2.81.0",
+          "from": "request@2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "from": "rimraf@2.6.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "from": "safe-buffer@5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+        },
+        "semver": {
+          "version": "5.3.0",
+          "from": "semver@5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "from": "set-blocking@2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "from": "signal-exit@3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "from": "sntp@1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "optional": true
+        },
+        "sshpk": {
+          "version": "1.13.1",
+          "from": "sshpk@1.13.1",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "from": "string_decoder@1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "from": "safe-buffer@5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "from": "stringstream@0.0.5",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "from": "strip-ansi@3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "from": "strip-json-comments@2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "from": "tar@2.2.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "from": "tar-pack@3.4.0",
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "optional": true
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "from": "tough-cookie@2.3.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "from": "tunnel-agent@0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "from": "tweetnacl@0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "from": "uid-number@0.0.6",
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "from": "util-deprecate@1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "from": "uuid@3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "from": "verror@1.3.6",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "from": "wide-align@1.1.2",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "optional": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "from": "wrappy@1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        }
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "from": "imurmurhash@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "from": "inflight@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "from": "inherits@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+    },
+    "ini": {
+      "version": "1.3.4",
+      "from": "ini@>=1.3.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "from": "inquirer@>=0.12.0 <0.13.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz"
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "from": "is-buffer@>=1.1.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "from": "is-dotfile@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "from": "is-extendable@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "from": "is-extglob@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "from": "is-finite@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "from": "is-glob@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+    },
+    "is-my-json-valid": {
+      "version": "2.16.0",
+      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz"
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "from": "is-number@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "from": "is-path-cwd@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "from": "is-path-inside@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "from": "is-primitive@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "from": "is-property@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+    },
+    "is-resolvable": {
+      "version": "1.0.0",
+      "from": "is-resolvable@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+    },
+    "is-windows": {
+      "version": "0.2.0",
+      "from": "is-windows@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "from": "isarray@1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "from": "isexe@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "from": "isobject@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "from": "isstream@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+    },
+    "istanbul": {
+      "version": "0.4.5",
+      "from": "istanbul@>=0.4.5 <0.5.0",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "from": "glob@>=5.0.15 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         },
         "supports-color": {
           "version": "3.2.3",
           "from": "supports-color@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0",
-              "from": "has-flag@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-            }
-          }
-        },
-        "which": {
-          "version": "1.2.14",
-          "from": "which@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "dependencies": {
-            "isexe": {
-              "version": "2.0.0",
-              "from": "isexe@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-            }
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "from": "wordwrap@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
         }
       }
+    },
+    "js-yaml": {
+      "version": "3.9.0",
+      "from": "js-yaml@>=3.3.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "from": "esprima@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "from": "jsbn@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "optional": true
+    },
+    "jshint": {
+      "version": "2.9.5",
+      "from": "jshint@>=2.9.4 <2.10.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "3.7.0",
+          "from": "lodash@>=3.7.0 <3.8.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
+        }
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "from": "json-schema@0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "from": "jsonify@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "from": "jsonpointer@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
+    },
+    "jsprim": {
+      "version": "1.4.0",
+      "from": "jsprim@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "from": "kind-of@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "from": "lazy-cache@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "optional": true
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "from": "lazystream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
+    },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "from": "lcov-parse@0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz"
+    },
+    "levn": {
+      "version": "0.3.0",
+      "from": "levn@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
     },
     "lodash": {
       "version": "4.17.4",
-      "from": "lodash@>=4.8.2 <5.0.0",
+      "from": "lodash@>=4.17.4 <4.18.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+    },
+    "log-driver": {
+      "version": "1.2.5",
+      "from": "log-driver@1.2.5",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz"
+    },
+    "longest": {
+      "version": "1.0.1",
+      "from": "longest@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "from": "lru-cache@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz"
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "from": "micromatch@>=2.3.7 <3.0.0",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+    },
+    "mime-db": {
+      "version": "1.27.0",
+      "from": "mime-db@>=1.27.0 <1.28.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+    },
+    "mime-types": {
+      "version": "2.1.15",
+      "from": "mime-types@>=2.1.7 <2.2.0",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "from": "minimatch@>=3.0.4 <4.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "from": "minimist@1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "from": "mkdirp@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "from": "ms@2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "from": "mute-stream@0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+    },
+    "nan": {
+      "version": "2.6.2",
+      "from": "nan@>=2.6.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+      "optional": true
+    },
+    "nodeunit": {
+      "version": "0.9.5",
+      "from": "nodeunit@>=0.9.0 <0.10.0",
+      "resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.9.5.tgz"
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "from": "nopt@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "from": "normalize-path@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
+    },
+    "npm-run-path": {
+      "version": "1.0.0",
+      "from": "npm-run-path@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz"
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "from": "number-is-nan@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+    },
+    "nyc": {
+      "version": "7.1.0",
+      "from": "nyc@>=7.1.0 <8.0.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-7.1.0.tgz",
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "from": "align-text@>=0.1.3 <0.2.0",
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+        },
+        "amdefine": {
+          "version": "1.0.0",
+          "from": "amdefine@>=0.0.4",
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "from": "ansi-regex@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "from": "ansi-styles@>=2.2.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+        },
+        "append-transform": {
+          "version": "0.3.0",
+          "from": "append-transform@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.3.0.tgz"
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "from": "arr-diff@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
+        },
+        "arr-flatten": {
+          "version": "1.0.1",
+          "from": "arr-flatten@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "from": "array-unique@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "from": "arrify@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+        },
+        "async": {
+          "version": "1.5.2",
+          "from": "async@>=1.4.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "babel-code-frame": {
+          "version": "6.11.0",
+          "from": "babel-code-frame@>=6.8.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz"
+        },
+        "babel-generator": {
+          "version": "6.11.4",
+          "from": "babel-generator@>=6.11.3 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.11.4.tgz"
+        },
+        "babel-messages": {
+          "version": "6.8.0",
+          "from": "babel-messages@>=6.8.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+        },
+        "babel-runtime": {
+          "version": "6.9.2",
+          "from": "babel-runtime@>=6.9.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz"
+        },
+        "babel-template": {
+          "version": "6.9.0",
+          "from": "babel-template@>=6.9.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.9.0.tgz"
+        },
+        "babel-traverse": {
+          "version": "6.11.4",
+          "from": "babel-traverse@>=6.9.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.11.4.tgz"
+        },
+        "babel-types": {
+          "version": "6.11.1",
+          "from": "babel-types@>=6.10.2 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.11.1.tgz"
+        },
+        "babylon": {
+          "version": "6.8.4",
+          "from": "babylon@>=6.8.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz"
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "from": "balanced-match@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+        },
+        "brace-expansion": {
+          "version": "1.1.6",
+          "from": "brace-expansion@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+        },
+        "braces": {
+          "version": "1.8.5",
+          "from": "braces@>=1.8.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "from": "builtin-modules@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "from": "caching-transform@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz"
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "from": "camelcase@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "from": "center-align@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "from": "cliui@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "optional": true,
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.0.0",
+          "from": "code-point-at@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "from": "commondir@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "from": "concat-map@0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+        },
+        "convert-source-map": {
+          "version": "1.3.0",
+          "from": "convert-source-map@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz"
+        },
+        "core-js": {
+          "version": "2.4.1",
+          "from": "core-js@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+        },
+        "cross-spawn": {
+          "version": "4.0.0",
+          "from": "cross-spawn@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.0.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "from": "decamelize@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "from": "default-require-extensions@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz"
+        },
+        "detect-indent": {
+          "version": "3.0.1",
+          "from": "detect-indent@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            }
+          }
+        },
+        "error-ex": {
+          "version": "1.3.0",
+          "from": "error-ex@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "from": "esutils@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "from": "expand-brackets@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "from": "expand-range@>=1.8.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "from": "extglob@>=0.3.1 <0.4.0",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+        },
+        "filename-regex": {
+          "version": "2.0.0",
+          "from": "filename-regex@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "from": "fill-range@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "from": "find-cache-dir@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz"
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "from": "find-up@>=1.1.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+        },
+        "for-in": {
+          "version": "0.1.5",
+          "from": "for-in@>=0.1.5 <0.2.0",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
+        },
+        "for-own": {
+          "version": "0.1.4",
+          "from": "for-own@>=0.1.3 <0.2.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
+        },
+        "foreground-child": {
+          "version": "1.5.3",
+          "from": "foreground-child@>=1.5.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.3.tgz"
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "from": "fs.realpath@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+        },
+        "get-caller-file": {
+          "version": "1.0.1",
+          "from": "get-caller-file@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.1.tgz"
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "from": "get-stdin@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+        },
+        "glob": {
+          "version": "7.0.5",
+          "from": "glob@>=7.0.3 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "from": "glob-base@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "from": "glob-parent@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+        },
+        "globals": {
+          "version": "8.18.0",
+          "from": "globals@>=8.3.0 <9.0.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
+        },
+        "graceful-fs": {
+          "version": "4.1.4",
+          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+        },
+        "handlebars": {
+          "version": "4.0.5",
+          "from": "handlebars@>=4.0.3 <5.0.0",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@>=0.4.4 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "from": "has-ansi@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "from": "has-flag@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+        },
+        "hosted-git-info": {
+          "version": "2.1.5",
+          "from": "hosted-git-info@>=2.1.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "from": "imurmurhash@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+        },
+        "inflight": {
+          "version": "1.0.5",
+          "from": "inflight@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "invariant": {
+          "version": "2.2.1",
+          "from": "invariant@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "from": "invert-kv@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "from": "is-arrayish@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+        },
+        "is-buffer": {
+          "version": "1.1.3",
+          "from": "is-buffer@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "from": "is-builtin-module@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
+        },
+        "is-dotfile": {
+          "version": "1.0.2",
+          "from": "is-dotfile@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "from": "is-extendable@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "from": "is-extglob@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+        },
+        "is-finite": {
+          "version": "1.0.1",
+          "from": "is-finite@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "from": "is-glob@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "from": "is-number@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "from": "is-primitive@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "from": "is-utf8@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "isexe": {
+          "version": "1.1.2",
+          "from": "isexe@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "from": "isobject@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.0.0-alpha.4",
+          "from": "istanbul-lib-coverage@>=1.0.0-alpha.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0-alpha.4.tgz"
+        },
+        "istanbul-lib-hook": {
+          "version": "1.0.0-alpha.4",
+          "from": "istanbul-lib-hook@>=1.0.0-alpha.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0-alpha.4.tgz"
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.1.0-alpha.4",
+          "from": "istanbul-lib-instrument@>=1.1.0-alpha.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.1.0-alpha.4.tgz"
+        },
+        "istanbul-lib-report": {
+          "version": "1.0.0-alpha.3",
+          "from": "istanbul-lib-report@>=1.0.0-alpha.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.0.0-alpha.3.tgz",
+          "dependencies": {
+            "supports-color": {
+              "version": "3.1.2",
+              "from": "supports-color@>=3.1.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.0.0-alpha.10",
+          "from": "istanbul-lib-source-maps@>=1.0.0-alpha.10 <2.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.0.0-alpha.10.tgz"
+        },
+        "istanbul-reports": {
+          "version": "1.0.0-alpha.8",
+          "from": "istanbul-reports@>=1.0.0-alpha.8 <2.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.0-alpha.8.tgz"
+        },
+        "js-tokens": {
+          "version": "2.0.0",
+          "from": "js-tokens@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
+        },
+        "kind-of": {
+          "version": "3.0.3",
+          "from": "kind-of@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz"
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "from": "lazy-cache@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "from": "lcid@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "from": "load-json-file@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
+        },
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@>=4.2.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        },
+        "lodash.assign": {
+          "version": "4.0.9",
+          "from": "lodash.assign@>=4.0.9 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz"
+        },
+        "lodash.keys": {
+          "version": "4.0.7",
+          "from": "lodash.keys@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz"
+        },
+        "lodash.rest": {
+          "version": "4.0.3",
+          "from": "lodash.rest@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz"
+        },
+        "longest": {
+          "version": "1.0.1",
+          "from": "longest@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+        },
+        "loose-envify": {
+          "version": "1.2.0",
+          "from": "loose-envify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
+          "dependencies": {
+            "js-tokens": {
+              "version": "1.0.3",
+              "from": "js-tokens@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
+            }
+          }
+        },
+        "lru-cache": {
+          "version": "4.0.1",
+          "from": "lru-cache@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "from": "md5-hex@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz"
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "from": "md5-o-matic@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "from": "micromatch@>=2.3.11 <3.0.0",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.2",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        },
+        "normalize-package-data": {
+          "version": "2.3.5",
+          "from": "normalize-package-data@>=2.3.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
+        },
+        "normalize-path": {
+          "version": "2.0.1",
+          "from": "normalize-path@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+        },
+        "number-is-nan": {
+          "version": "1.0.0",
+          "from": "number-is-nan@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+        },
+        "object.omit": {
+          "version": "2.0.0",
+          "from": "object.omit@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
+        },
+        "once": {
+          "version": "1.3.3",
+          "from": "once@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
+        },
+        "os-homedir": {
+          "version": "1.0.1",
+          "from": "os-homedir@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "from": "os-locale@>=1.4.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "from": "parse-glob@>=3.0.4 <4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "from": "parse-json@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "from": "path-exists@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "from": "path-parse@>=1.0.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "from": "path-type@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+        },
+        "pify": {
+          "version": "2.3.0",
+          "from": "pify@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "from": "pinkie@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "from": "pkg-dir@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+        },
+        "pkg-up": {
+          "version": "1.0.0",
+          "from": "pkg-up@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz"
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "from": "preserve@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "from": "pseudomap@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+        },
+        "randomatic": {
+          "version": "1.1.5",
+          "from": "randomatic@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "from": "read-pkg@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "from": "read-pkg-up@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.9.5",
+          "from": "regenerator-runtime@>=0.9.5 <0.10.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
+        },
+        "regex-cache": {
+          "version": "0.4.3",
+          "from": "regex-cache@>=0.4.2 <0.5.0",
+          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "from": "repeat-element@>=1.1.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+        },
+        "repeat-string": {
+          "version": "1.5.4",
+          "from": "repeat-string@>=1.5.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+        },
+        "repeating": {
+          "version": "1.1.3",
+          "from": "repeating@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "from": "require-directory@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "from": "require-main-filename@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "from": "resolve-from@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "from": "right-align@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "from": "rimraf@>=2.5.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+        },
+        "semver": {
+          "version": "5.3.0",
+          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "from": "set-blocking@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+        },
+        "signal-exit": {
+          "version": "3.0.0",
+          "from": "signal-exit@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
+        },
+        "slide": {
+          "version": "1.1.6",
+          "from": "slide@>=1.1.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        },
+        "spawn-wrap": {
+          "version": "1.2.4",
+          "from": "spawn-wrap@>=1.2.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.2.4.tgz",
+          "dependencies": {
+            "signal-exit": {
+              "version": "2.1.2",
+              "from": "signal-exit@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "from": "spdx-correct@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
+        },
+        "spdx-exceptions": {
+          "version": "1.0.5",
+          "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.5.tgz"
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.2",
+          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
+        },
+        "spdx-license-ids": {
+          "version": "1.2.1",
+          "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
+        },
+        "string-width": {
+          "version": "1.0.1",
+          "from": "string-width@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "from": "strip-ansi@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "from": "strip-bom@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+        },
+        "test-exclude": {
+          "version": "1.1.0",
+          "from": "test-exclude@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-1.1.0.tgz"
+        },
+        "to-fast-properties": {
+          "version": "1.0.2",
+          "from": "to-fast-properties@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+        },
+        "uglify-js": {
+          "version": "2.7.0",
+          "from": "uglify-js@>=2.6.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.0.tgz",
+          "optional": true,
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "optional": true
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "from": "yargs@>=3.10.0 <3.11.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "optional": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+        },
+        "which": {
+          "version": "1.2.10",
+          "from": "which@>=1.2.9 <2.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "from": "which-module@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "from": "window-size@0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "from": "wordwrap@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+        },
+        "wrap-ansi": {
+          "version": "2.0.0",
+          "from": "wrap-ansi@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "from": "wrappy@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        },
+        "write-file-atomic": {
+          "version": "1.1.4",
+          "from": "write-file-atomic@>=1.1.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz"
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "from": "y18n@>=3.2.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+        },
+        "yallist": {
+          "version": "2.0.0",
+          "from": "yallist@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "from": "yargs@>=4.8.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "dependencies": {
+            "cliui": {
+              "version": "3.2.0",
+              "from": "cliui@>=3.2.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
+            },
+            "window-size": {
+              "version": "0.2.0",
+              "from": "window-size@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "from": "yargs-parser@>=2.4.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "from": "camelcase@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "from": "oauth-sign@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "from": "object-assign@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "from": "object.omit@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
+    },
+    "once": {
+      "version": "1.4.0",
+      "from": "once@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "from": "onetime@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+    },
+    "only-shallow": {
+      "version": "1.2.0",
+      "from": "only-shallow@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/only-shallow/-/only-shallow-1.2.0.tgz"
+    },
+    "opener": {
+      "version": "1.4.3",
+      "from": "opener@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz"
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "from": "optimist@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "from": "minimist@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "from": "wordwrap@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "from": "optionator@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz"
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "from": "os-homedir@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "from": "parse-glob@>=3.0.4 <4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
+    },
+    "parse-ms": {
+      "version": "1.0.1",
+      "from": "parse-ms@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz"
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "from": "parse-passwd@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz"
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "from": "path-is-inside@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+    },
+    "path-key": {
+      "version": "1.0.0",
+      "from": "path-key@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz"
+    },
+    "pify": {
+      "version": "2.3.0",
+      "from": "pify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "from": "pinkie@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+    },
+    "plur": {
+      "version": "1.0.0",
+      "from": "plur@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz"
+    },
+    "pluralize": {
+      "version": "1.2.1",
+      "from": "pluralize@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "from": "prelude-ls@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "from": "preserve@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+    },
+    "pretty-bytes": {
+      "version": "4.0.2",
+      "from": "pretty-bytes@>=4.0.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz"
+    },
+    "pretty-ms": {
+      "version": "2.1.0",
+      "from": "pretty-ms@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz"
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+    },
+    "progress": {
+      "version": "1.1.8",
+      "from": "progress@>=1.1.8 <2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "from": "pseudomap@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "from": "punycode@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+    },
+    "qs": {
+      "version": "6.3.2",
+      "from": "qs@>=6.3.0 <6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz"
+    },
+    "randomatic": {
+      "version": "1.1.7",
+      "from": "randomatic@>=1.1.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "from": "is-number@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "from": "kind-of@^3.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "from": "kind-of@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "from": "readable-stream@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "from": "readline2@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
+    },
+    "regex-cache": {
+      "version": "0.4.3",
+      "from": "regex-cache@>=0.4.2 <0.5.0",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+    },
+    "remove-trailing-separator": {
+      "version": "1.0.2",
+      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "from": "repeat-element@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "from": "repeat-string@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+    },
+    "request": {
+      "version": "2.79.0",
+      "from": "request@2.79.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz"
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "from": "require-uncached@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz"
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "from": "resolve@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+    },
+    "resolve-dir": {
+      "version": "0.1.1",
+      "from": "resolve-dir@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "from": "resolve-from@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "from": "restore-cursor@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "from": "right-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "optional": true
+    },
+    "rimraf": {
+      "version": "2.6.1",
+      "from": "rimraf@>=2.5.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "from": "run-async@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "from": "rx-lite@>=3.1.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "from": "safe-buffer@>=5.1.1 <5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "from": "shelljs@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "from": "signal-exit@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "from": "slice-ansi@0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "from": "sntp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+    },
+    "source-map": {
+      "version": "0.2.0",
+      "from": "source-map@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "optional": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "from": "sprintf-js@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "from": "sshpk@>=1.7.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "stack-utils": {
+      "version": "0.4.0",
+      "from": "stack-utils@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-0.4.0.tgz"
+    },
+    "stream-buffers": {
+      "version": "2.2.0",
+      "from": "stream-buffers@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz"
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "from": "string_decoder@>=1.0.3 <1.1.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "from": "string-width@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "from": "stringstream@>=0.0.4 <0.1.0",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "from": "strip-json-comments@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "from": "supports-color@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+    },
+    "table": {
+      "version": "3.8.3",
+      "from": "table@>=3.7.8 <4.0.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+        },
+        "string-width": {
+          "version": "2.1.0",
+          "from": "string-width@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz"
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+        }
+      }
+    },
+    "tap": {
+      "version": "7.1.2",
+      "from": "tap@>=7.0.0 <8.0.0",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-7.1.2.tgz",
+      "dependencies": {
+        "isexe": {
+          "version": "1.1.2",
+          "from": "isexe@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+        },
+        "os-homedir": {
+          "version": "1.0.1",
+          "from": "os-homedir@1.0.1",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+        }
+      }
+    },
+    "tap-mocha-reporter": {
+      "version": "2.0.1",
+      "from": "tap-mocha-reporter@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-2.0.1.tgz"
+    },
+    "tap-parser": {
+      "version": "2.2.3",
+      "from": "tap-parser@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-2.2.3.tgz"
+    },
+    "tar-stream": {
+      "version": "1.5.4",
+      "from": "tar-stream@>=1.5.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz"
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "from": "text-table@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+    },
+    "through": {
+      "version": "2.3.8",
+      "from": "through@>=2.3.6 <3.0.0",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "time-grunt": {
       "version": "1.4.0",
-      "from": "time-grunt@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.4.0.tgz",
+      "from": "time-grunt@>=1.4.0 <1.5.0",
+      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.4.0.tgz"
+    },
+    "time-zone": {
+      "version": "0.1.0",
+      "from": "time-zone@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-0.1.0.tgz"
+    },
+    "tmatch": {
+      "version": "2.0.1",
+      "from": "tmatch@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz"
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "from": "tough-cookie@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+    },
+    "tryit": {
+      "version": "1.0.3",
+      "from": "tryit@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "from": "tunnel-agent@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "from": "type-check@>=0.3.2 <0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "from": "typedarray@>=0.0.6 <0.0.7",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "from": "uglify-js@>=2.6.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "optional": true,
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "date-time": {
-          "version": "1.1.0",
-          "from": "date-time@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.1.0.tgz",
-          "dependencies": {
-            "time-zone": {
-              "version": "0.1.0",
-              "from": "time-zone@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-0.1.0.tgz"
-            }
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "from": "figures@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "dependencies": {
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.1.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            }
-          }
-        },
-        "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "from": "number-is-nan@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-        },
-        "pretty-ms": {
-          "version": "2.1.0",
-          "from": "pretty-ms@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
-          "dependencies": {
-            "is-finite": {
-              "version": "1.0.2",
-              "from": "is-finite@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-            },
-            "parse-ms": {
-              "version": "1.0.1",
-              "from": "parse-ms@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz"
-            },
-            "plur": {
-              "version": "1.0.0",
-              "from": "plur@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz"
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        "source-map": {
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "optional": true
         }
       }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "optional": true
+    },
+    "unicode-length": {
+      "version": "1.0.3",
+      "from": "unicode-length@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz"
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "from": "user-home@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "from": "uuid@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+    },
+    "verror": {
+      "version": "1.3.6",
+      "from": "verror@1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+    },
+    "walkdir": {
+      "version": "0.0.11",
+      "from": "walkdir@>=0.0.11 <0.0.12",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz"
+    },
+    "which": {
+      "version": "1.2.14",
+      "from": "which@>=1.2.12 <2.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "from": "window-size@0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "from": "wordwrap@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "from": "wrappy@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+    },
+    "write": {
+      "version": "0.2.1",
+      "from": "write@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "from": "xtend@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "from": "yallist@>=2.1.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "from": "yargs@>=3.10.0 <3.11.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "optional": true
+    },
+    "zip-stream": {
+      "version": "1.2.0",
+      "from": "zip-stream@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-fh-build",
   "description": "A plugin for development and build lifecycle of FeedHenry components",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "homepage": "https://github.com/feedhenry/grunt-fh-build",
   "author": "Red Hat",
   "license": "Apache-2.0",
@@ -13,7 +13,7 @@
     "url": "https://github.com/feedhenry/grunt-fh-build/issues"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": "6.9"
   },
   "scripts": {
     "test": "grunt eslint",
@@ -31,7 +31,7 @@
   "dependencies": {
     "findup-sync": "^0.4.0",
     "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-compress": "1.2.0",
+    "grunt-contrib-compress": "~1.4.3",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-nodeunit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-fh-build",
   "description": "A plugin for development and build lifecycle of FeedHenry components",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "homepage": "https://github.com/feedhenry/grunt-fh-build",
   "author": "Red Hat",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -29,17 +29,17 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "findup-sync": "^0.4.0",
-    "grunt-contrib-clean": "^1.0.0",
+    "findup-sync": "~0.4.3",
+    "grunt-contrib-clean": "~1.1.0",
     "grunt-contrib-compress": "~1.4.3",
-    "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-nodeunit": "^1.0.0",
-    "grunt-env": "^0.4.4",
-    "grunt-eslint": "^18.0.0",
-    "grunt-shell": "^1.1.2",
-    "istanbul": "^0.4.3",
-    "lodash": "^4.8.2",
-    "time-grunt": "^1.1.1"
+    "grunt-contrib-copy": "~1.0.0",
+    "grunt-contrib-jshint": "~1.1.0",
+    "grunt-contrib-nodeunit": "~1.0.0",
+    "grunt-env": "~0.4.4",
+    "grunt-eslint": "~18.1.0",
+    "grunt-shell": "~1.3.1",
+    "istanbul": "~0.4.5",
+    "lodash": "~4.17.4",
+    "time-grunt": "~1.4.0"
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=grunt-fh-build
 sonar.projectName=grunt-fh-build-nightly-master
-sonar.projectVersion=1.0.2
+sonar.projectVersion=1.1.0
 
 sonar.sources=./tasks
 sonar.language=js

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=grunt-fh-build
 sonar.projectName=grunt-fh-build-nightly-master
-sonar.projectVersion=1.1.0
+sonar.projectVersion=2.0.0
 
 sonar.sources=./tasks
 sonar.language=js


### PR DESCRIPTION
### Node 6 - NPM 3 support:
- `npm ls --parseable --production` is used since, empirically, it is equivalent to `npm pack` in terms of which directories they pick under `node_modules`. `npm pack` is not used directly because it has undocumented subtle pitfalls e.g. it skips the builds of native dependencies, see [here](https://github.com/Automattic/node-canvas/issues/233)

### Node 6 support (in order to test other Node 6 related PRs):
- Update engines to 6.9
- Update grunt-contrib-compress
- Change `^` to `~` in dependencies

### JIRA: https://issues.jboss.org/browse/FH-2703